### PR TITLE
fix(deps): allow main panel to open when standalone Python is absent

### DIFF
--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -917,11 +917,6 @@ def get_venv_status() -> Tuple[bool, str]:
     Returns:
         A tuple of (is_ready, status_message).
     """
-    from .python_manager import standalone_python_exists
-
-    if not standalone_python_exists():
-        return False, "Dependencies not installed"
-
     if not venv_exists():
         return False, "Virtual environment not configured"
 

--- a/gee_data_catalogs/dialogs/dependency_dialog.py
+++ b/gee_data_catalogs/dialogs/dependency_dialog.py
@@ -38,6 +38,7 @@ class DependencyDockWidget(QDockWidget):
         self.iface = iface
         self._deps_worker = None
         self._auth_worker = None
+        self._has_emitted_success = False
 
         self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
         self._setup_ui()
@@ -144,7 +145,11 @@ class DependencyDockWidget(QDockWidget):
         layout.addStretch()
 
     def _refresh_deps_status(self):
-        """Refresh the dependency status display."""
+        """Refresh the dependency status display.
+
+        If all dependencies are already installed, emits install_succeeded
+        so the main plugin can proceed with the pending callback.
+        """
         from ..core.venv_manager import check_dependencies
 
         all_ok, missing, installed = check_dependencies()
@@ -165,6 +170,9 @@ class DependencyDockWidget(QDockWidget):
         if all_ok:
             self._install_btn.setText("All Dependencies Installed")
             self._update_auth_status()
+            if not self._has_emitted_success:
+                self._has_emitted_success = True
+                self.install_succeeded.emit()
         else:
             self._install_btn.setText(f"Install Dependencies ({len(missing)} missing)")
             self._auth_group.setVisible(False)
@@ -244,6 +252,7 @@ class DependencyDockWidget(QDockWidget):
             self.iface.messageBar().pushSuccess(
                 "GEE Data Catalogs", "Dependencies installed successfully!"
             )
+            self._has_emitted_success = True
             self.install_succeeded.emit()
 
             # Check if EE credentials exist and show auth section

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -229,12 +229,25 @@ class GeeDataCatalogs:
             callback()
             return
 
-        from .core.venv_manager import ensure_venv_packages_available, get_venv_status
+        from .core.venv_manager import (
+            check_dependencies,
+            ensure_venv_packages_available,
+            get_venv_status,
+        )
 
         is_ready, status_msg = get_venv_status()
 
         if is_ready:
             ensure_venv_packages_available()
+            self._deps_ready = True
+            self._try_auto_init_ee()
+            callback()
+            return
+
+        # Fallback: packages may already be available on sys.path
+        # (e.g., installed via conda, pixi, or system pip).
+        all_ok, _missing, _installed = check_dependencies()
+        if all_ok:
             self._deps_ready = True
             self._try_auto_init_ee()
             callback()

--- a/gee_data_catalogs/metadata.txt
+++ b/gee_data_catalogs/metadata.txt
@@ -2,7 +2,7 @@
 name=Earth Engine Data Catalogs
 qgisMinimumVersion=3.28
 description=Browse, search, and load Google Earth Engine data catalogs directly in QGIS.
-version=0.9.0
+version=0.9.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -36,6 +36,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.9.1
+        - Allow main panel to open when standalone Python is absent
     0.9.0
         - Fix Windows install launching QGIS, use uv and dockable panel
     0.8.0


### PR DESCRIPTION
## Summary

Fixes #49. The main Data Catalog panel fails to appear on macOS (and potentially other platforms) because `get_venv_status()` requires standalone Python to exist as its first gate check. When the standalone Python download fails (e.g., macOS Gatekeeper blocks the unsigned binary), the installer falls back to system Python and creates the venv successfully, but `get_venv_status()` permanently returns `False`, blocking the main panel from ever opening.

- Remove `standalone_python_exists()` from `get_venv_status()` since standalone Python is only needed for venv creation, not runtime status checking
- Add `check_dependencies()` fallback in `_ensure_dependencies()` for packages installed via conda, pixi, or system pip (not in the plugin's private venv)
- Emit `install_succeeded` when the deps panel opens and finds dependencies already installed, with a guard flag to prevent duplicate signal emissions

## Test plan

- [ ] Simulate macOS standalone-Python-failure: remove `~/.qgis_gee_data_catalogs/python_standalone/` while keeping venv intact, click Data Catalog -- panel should open directly
- [ ] Pixi/conda scenario: install earthengine-api and geemap in the active environment, remove the plugin's venv, click Data Catalog -- panel should open directly
- [ ] Fresh install regression: remove `~/.qgis_gee_data_catalogs/` entirely, click Data Catalog -- deps panel should open, install, then catalog panel should open automatically
- [ ] Already-installed regression: with full setup in place, click Data Catalog -- catalog panel should open directly without the deps panel