### PR TITLE
Qt5/Qt6 dual compatibility for QGIS 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+    push:
+        branches: ["**"]
+    pull_request:
+        branches: [main]
+
+jobs:
+    pre-commit:
+        name: pre-commit
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - uses: pre-commit/action@v3.0.1
+
+    bandit:
+        name: Bandit security scan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - name: Install Bandit
+              run: pip install bandit
+            - name: Run Bandit (matches plugins.qgis.org security scan)
+              run: bandit -r gee_data_catalogs
+
+    pyqt6-smoke:
+        name: PyQt6 import smoke
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.11", "3.12", "3.13"]
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install Qt6 runtime libs
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+            - name: Install PyQt6 and pytest
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install PyQt6 pytest
+            - name: Run import smoke tests
+              run: pytest tests -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,10 @@ repos:
       rev: 0.9.1
       hooks:
           - id: nbstripout
+
+    - repo: https://github.com/PyCQA/bandit
+      rev: 1.9.4
+      hooks:
+          - id: bandit
+            args: ["-r", "gee_data_catalogs"]
+            pass_filenames: false

--- a/gee_data_catalogs/core/_net.py
+++ b/gee_data_catalogs/core/_net.py
@@ -1,0 +1,28 @@
+"""Network helpers shared across the plugin."""
+
+from urllib.parse import urlparse
+from urllib.request import Request
+
+
+def require_https(url) -> None:
+    """Raise ValueError unless the URL uses the https scheme.
+
+    Bandit B310 flags ``urllib.request.urlopen`` calls because they accept any
+    scheme, including ``file://``. Every urlopen call site in this plugin only
+    fetches resources from known https endpoints (GitHub releases, GitHub raw,
+    plugin repository metadata). Calling this guard before urlopen makes that
+    invariant explicit, both at runtime and to security scanners.
+
+    Args:
+        url: Either a string URL or a :class:`urllib.request.Request`.
+
+    Raises:
+        ValueError: If the resolved scheme is not exactly ``https``.
+    """
+    if isinstance(url, Request):
+        target = url.full_url
+    else:
+        target = url
+    scheme = urlparse(target).scheme.lower()
+    if scheme != "https":
+        raise ValueError(f"Refusing to fetch non-https URL: {target!r}")

--- a/gee_data_catalogs/core/catalog_data.py
+++ b/gee_data_catalogs/core/catalog_data.py
@@ -17,6 +17,8 @@ from urllib.error import URLError, HTTPError
 
 from qgis.core import QgsMessageLog, Qgis, QgsSettings
 
+from ._net import require_https
+
 # URLs for catalog data
 OFFICIAL_CATALOG_TSV_URL = "https://raw.githubusercontent.com/opengeos/Earth-Engine-Catalog/master/gee_catalog.tsv"
 OFFICIAL_CATALOG_JSON_URL = "https://raw.githubusercontent.com/opengeos/Earth-Engine-Catalog/master/gee_catalog.json"
@@ -491,7 +493,9 @@ def _parse_json_catalog(content: str) -> List[Dict]:
                 datasets.append(dataset)
     except json.JSONDecodeError as e:
         QgsMessageLog.logMessage(
-            f"Failed to parse JSON catalog: {e}", "GEE Data Catalogs", Qgis.Warning
+            f"Failed to parse JSON catalog: {e}",
+            "GEE Data Catalogs",
+            Qgis.MessageLevel.Warning,
         )
 
     return datasets
@@ -607,7 +611,7 @@ def _parse_community_json(content: str) -> List[Dict]:
         QgsMessageLog.logMessage(
             f"Failed to parse community JSON catalog: {e}",
             "GEE Data Catalogs",
-            Qgis.Warning,
+            Qgis.MessageLevel.Warning,
         )
 
     return datasets
@@ -659,28 +663,33 @@ def fetch_official_catalog(use_cache: bool = True) -> List[Dict]:
     ]:
         try:
             QgsMessageLog.logMessage(
-                f"Fetching official catalog from: {url}", "GEE Data Catalogs", Qgis.Info
+                f"Fetching official catalog from: {url}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Info,
             )
-            with urlopen(url, timeout=30) as response:
+            require_https(url)
+            with urlopen(url, timeout=30) as response:  # nosec B310
                 content = response.read().decode("utf-8")
                 datasets = parser(content)
                 if datasets:
                     QgsMessageLog.logMessage(
                         f"Loaded {len(datasets)} datasets from official catalog",
                         "GEE Data Catalogs",
-                        Qgis.Info,
+                        Qgis.MessageLevel.Info,
                     )
                     _catalog_cache["official"] = datasets
                     return datasets
         except (HTTPError, URLError) as e:
             QgsMessageLog.logMessage(
-                f"Failed to fetch from {url}: {e}", "GEE Data Catalogs", Qgis.Warning
+                f"Failed to fetch from {url}: {e}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
             )
         except Exception as e:
             QgsMessageLog.logMessage(
                 f"Error parsing catalog from {url}: {e}",
                 "GEE Data Catalogs",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
 
     return datasets
@@ -711,28 +720,31 @@ def fetch_community_catalog(use_cache: bool = True) -> List[Dict]:
             QgsMessageLog.logMessage(
                 f"Fetching community catalog from: {url}",
                 "GEE Data Catalogs",
-                Qgis.Info,
+                Qgis.MessageLevel.Info,
             )
-            with urlopen(url, timeout=30) as response:
+            require_https(url)
+            with urlopen(url, timeout=30) as response:  # nosec B310
                 content = response.read().decode("utf-8")
                 datasets = parser(content)
                 if datasets:
                     QgsMessageLog.logMessage(
                         f"Loaded {len(datasets)} datasets from community catalog",
                         "GEE Data Catalogs",
-                        Qgis.Info,
+                        Qgis.MessageLevel.Info,
                     )
                     _catalog_cache["community"] = datasets
                     return datasets
         except (HTTPError, URLError) as e:
             QgsMessageLog.logMessage(
-                f"Failed to fetch from {url}: {e}", "GEE Data Catalogs", Qgis.Warning
+                f"Failed to fetch from {url}: {e}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
             )
         except Exception as e:
             QgsMessageLog.logMessage(
                 f"Error parsing catalog from {url}: {e}",
                 "GEE Data Catalogs",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
 
     return datasets
@@ -970,7 +982,9 @@ def clear_cache():
         "community": None,
         "last_update": None,
     }
-    QgsMessageLog.logMessage("Catalog cache cleared", "GEE Data Catalogs", Qgis.Info)
+    QgsMessageLog.logMessage(
+        "Catalog cache cleared", "GEE Data Catalogs", Qgis.MessageLevel.Info
+    )
 
 
 def refresh_catalogs() -> Dict:

--- a/gee_data_catalogs/core/ee_utils.py
+++ b/gee_data_catalogs/core/ee_utils.py
@@ -84,7 +84,7 @@ def initialize_ee(project: str = None, credentials: Any = None) -> bool:
         QgsMessageLog.logMessage(
             f"Attempting to initialize Earth Engine with project: {project if project else 'None'}",
             "GEE Data Catalogs",
-            Qgis.Info,
+            Qgis.MessageLevel.Info,
         )
 
         # Initialize without explicitly passing credentials=None
@@ -106,7 +106,7 @@ def initialize_ee(project: str = None, credentials: Any = None) -> bool:
         QgsMessageLog.logMessage(
             "Earth Engine initialized successfully!",
             "GEE Data Catalogs",
-            Qgis.Success,
+            Qgis.MessageLevel.Success,
         )
         return True
     except Exception as e:
@@ -149,14 +149,14 @@ def try_auto_initialize_ee() -> bool:
         QgsMessageLog.logMessage(
             f"Earth Engine auto-initialized with project: {project}",
             "GEE Data Catalogs",
-            Qgis.Info,
+            Qgis.MessageLevel.Info,
         )
         return True
     except Exception as e:
         QgsMessageLog.logMessage(
             f"Failed to auto-initialize Earth Engine: {e}",
             "GEE Data Catalogs",
-            Qgis.Warning,
+            Qgis.MessageLevel.Warning,
         )
         return False
 
@@ -389,19 +389,19 @@ def _store_ee_layer_metadata(
         try:
             # Try to get the asset ID from the image
             asset_id = ee_object.get("system:id").getInfo()
-        except Exception:
+        except Exception:  # nosec B110
             pass
     elif isinstance(ee_object, ee.ImageCollection):
         object_type = "ImageCollection"
         try:
             asset_id = ee_object.get("system:id").getInfo()
-        except Exception:
+        except Exception:  # nosec B110
             pass
     elif isinstance(ee_object, ee.FeatureCollection):
         object_type = "FeatureCollection"
         try:
             asset_id = ee_object.get("system:id").getInfo()
-        except Exception:
+        except Exception:  # nosec B110
             pass
 
     # Store metadata as custom properties
@@ -492,7 +492,7 @@ def refresh_ee_layer(layer: QgsRasterLayer) -> bool:
         QgsMessageLog.logMessage(
             f"Refreshed EE layer: {layer.name()}",
             "GEE Data Catalogs",
-            Qgis.Info,
+            Qgis.MessageLevel.Info,
         )
         return True
 
@@ -500,7 +500,7 @@ def refresh_ee_layer(layer: QgsRasterLayer) -> bool:
         QgsMessageLog.logMessage(
             f"Failed to refresh EE layer '{layer.name()}': {e}",
             "GEE Data Catalogs",
-            Qgis.Warning,
+            Qgis.MessageLevel.Warning,
         )
         return False
 
@@ -569,7 +569,7 @@ def detect_asset_type(asset_id: str) -> str:
         fc = ee.FeatureCollection(asset_id)
         fc.size().getInfo()
         return "FeatureCollection"
-    except Exception:
+    except Exception:  # nosec B110
         pass
 
     return "Unknown"
@@ -613,7 +613,7 @@ def load_ee_asset(asset_id: str, asset_type: str = None) -> Any:
                 else:
                     obj.size().getInfo()
                 return obj
-            except Exception:
+            except Exception:  # nosec B112
                 continue
         raise ValueError(f"Could not load asset: {asset_id}")
 

--- a/gee_data_catalogs/core/python_manager.py
+++ b/gee_data_catalogs/core/python_manager.py
@@ -40,12 +40,12 @@ PYTHON_VERSIONS = {
 }
 
 
-def _log(message: str, level=Qgis.Info):
+def _log(message: str, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning, Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), PLUGIN_NAME, level=level)
 
@@ -216,7 +216,7 @@ def download_python_standalone(
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
-            _log(error_msg, Qgis.Critical)
+            _log(error_msg, Qgis.MessageLevel.Critical)
             return False, error_msg
 
         if cancel_check and cancel_check():
@@ -266,7 +266,7 @@ def download_python_standalone(
         return False, "Download cancelled"
     except Exception as e:
         error_msg = f"Installation failed: {str(e)}"
-        _log(error_msg, Qgis.Critical)
+        _log(error_msg, Qgis.MessageLevel.Critical)
 
         if sys.platform == "win32":
             error_lower = str(e).lower()
@@ -336,14 +336,17 @@ def verify_standalone_python() -> Tuple[bool, str]:
             if not version_output.startswith(
                 f"{sys.version_info.major}.{sys.version_info.minor}"
             ):
-                _log(f"Python version mismatch: got {version_output}", Qgis.Warning)
+                _log(
+                    f"Python version mismatch: got {version_output}",
+                    Qgis.MessageLevel.Warning,
+                )
                 return False, f"Version mismatch: {version_output}"
 
             _log(f"Verified Python standalone: {version_output}")
             return True, f"Python {version_output} verified"
         else:
             error = result.stderr or "Unknown error"
-            _log(f"Python verification failed: {error}", Qgis.Warning)
+            _log(f"Python verification failed: {error}", Qgis.MessageLevel.Warning)
             return False, f"Verification failed: {error[:100]}"
 
     except subprocess.TimeoutExpired:
@@ -367,5 +370,5 @@ def remove_standalone_python() -> Tuple[bool, str]:
         return True, "Standalone Python removed"
     except Exception as e:
         error_msg = f"Failed to remove: {str(e)}"
-        _log(error_msg, Qgis.Warning)
+        _log(error_msg, Qgis.MessageLevel.Warning)
         return False, error_msg

--- a/gee_data_catalogs/core/uv_manager.py
+++ b/gee_data_catalogs/core/uv_manager.py
@@ -30,12 +30,12 @@ UV_DIR = os.path.join(CACHE_DIR, "uv")
 UV_VERSION = "0.10.6"
 
 
-def _log(message: str, level=Qgis.Info):
+def _log(message: str, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning, Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), PLUGIN_NAME, level=level)
 
@@ -143,7 +143,7 @@ def download_uv(
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
-            _log(error_msg, Qgis.Critical)
+            _log(error_msg, Qgis.MessageLevel.Critical)
             return False, error_msg
 
         if cancel_check and cancel_check():
@@ -223,7 +223,7 @@ def download_uv(
         return False, "Download cancelled"
     except Exception as e:
         error_msg = f"uv installation failed: {str(e)}"
-        _log(error_msg, Qgis.Critical)
+        _log(error_msg, Qgis.MessageLevel.Critical)
         return False, error_msg
     finally:
         if os.path.exists(temp_path):
@@ -284,7 +284,7 @@ def verify_uv() -> Tuple[bool, str]:
             return True, version_output
         else:
             error = result.stderr or "Unknown error"
-            _log(f"uv verification failed: {error}", Qgis.Warning)
+            _log(f"uv verification failed: {error}", Qgis.MessageLevel.Warning)
             return False, f"Verification failed: {error[:100]}"
 
     except subprocess.TimeoutExpired:
@@ -308,5 +308,5 @@ def remove_uv() -> Tuple[bool, str]:
         return True, "uv removed"
     except Exception as e:
         error_msg = f"Failed to remove uv: {str(e)}"
-        _log(error_msg, Qgis.Warning)
+        _log(error_msg, Qgis.MessageLevel.Warning)
         return False, error_msg

--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -28,12 +28,12 @@ REQUIRED_PACKAGES = [
 ]
 
 
-def _log(message: str, level=Qgis.Info):
+def _log(message: str, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning, Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), PLUGIN_NAME, level=level)
 
@@ -270,7 +270,7 @@ def _get_system_python() -> str:
     if python_path and os.path.isfile(python_path):
         _log(
             f"Standalone Python unavailable, using system Python: {python_path}",
-            Qgis.Warning,
+            Qgis.MessageLevel.Warning,
         )
         return python_path
 
@@ -296,7 +296,10 @@ def _cleanup_partial_venv(venv_dir: str):
             shutil.rmtree(venv_dir, ignore_errors=True)
             _log(f"Cleaned up partial venv: {venv_dir}")
         except Exception:
-            _log(f"Could not clean up partial venv: {venv_dir}", Qgis.Warning)
+            _log(
+                f"Could not clean up partial venv: {venv_dir}",
+                Qgis.MessageLevel.Warning,
+            )
 
 
 def create_venv(
@@ -380,11 +383,14 @@ def create_venv(
                             _log("pip bootstrapped via ensurepip")
                         else:
                             err = ensurepip_result.stderr or ensurepip_result.stdout
-                            _log(f"ensurepip failed: {err[:200]}", Qgis.Warning)
+                            _log(
+                                f"ensurepip failed: {err[:200]}",
+                                Qgis.MessageLevel.Warning,
+                            )
                             _cleanup_partial_venv(venv_dir)
                             return False, f"Failed to bootstrap pip: {err[:200]}"
                     except Exception as e:
-                        _log(f"ensurepip exception: {e}", Qgis.Warning)
+                        _log(f"ensurepip exception: {e}", Qgis.MessageLevel.Warning)
                         _cleanup_partial_venv(venv_dir)
                         return False, f"Failed to bootstrap pip: {str(e)[:200]}"
 
@@ -395,19 +401,21 @@ def create_venv(
             error_msg = (
                 result.stderr or result.stdout or f"Return code {result.returncode}"
             )
-            _log(f"Failed to create venv: {error_msg}", Qgis.Critical)
+            _log(f"Failed to create venv: {error_msg}", Qgis.MessageLevel.Critical)
             _cleanup_partial_venv(venv_dir)
             return False, f"Failed to create venv: {error_msg[:200]}"
 
     except subprocess.TimeoutExpired:
-        _log("Virtual environment creation timed out", Qgis.Critical)
+        _log("Virtual environment creation timed out", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)
         return False, "Virtual environment creation timed out"
     except FileNotFoundError:
-        _log(f"Python executable not found: {system_python}", Qgis.Critical)
+        _log(
+            f"Python executable not found: {system_python}", Qgis.MessageLevel.Critical
+        )
         return False, f"Python not found: {system_python}"
     except Exception as e:
-        _log(f"Exception during venv creation: {str(e)}", Qgis.Critical)
+        _log(f"Exception during venv creation: {str(e)}", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)
         return False, f"Error: {str(e)[:200]}"
 
@@ -608,7 +616,7 @@ def _run_install(
             _log(
                 f"SSL error installing dependencies via {installer}, "
                 f"retrying with trusted hosts",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             retry_cmd = cmd + ssl_flags
             returncode, stdout, retry_stderr = _run_install_subprocess(
@@ -625,7 +633,7 @@ def _run_install(
             _log(
                 f"Network error installing dependencies via {installer}, "
                 f"retrying in 5s...",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             time.sleep(5)
             returncode, stdout, retry_stderr = _run_install_subprocess(
@@ -824,17 +832,19 @@ def verify_venv(
                 )
                 _log(
                     f"Package {package_name} verification failed: {error_detail}",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
                 return False, (
                     f"Package {package_name} is broken: {error_detail[:200]}"
                 )
 
         except subprocess.TimeoutExpired:
-            _log(f"Verification of {package_name} timed out", Qgis.Warning)
+            _log(f"Verification of {package_name} timed out", Qgis.MessageLevel.Warning)
             return False, f"Verification of {package_name} timed out"
         except Exception as e:
-            _log(f"Failed to verify {package_name}: {str(e)}", Qgis.Warning)
+            _log(
+                f"Failed to verify {package_name}: {str(e)}", Qgis.MessageLevel.Warning
+            )
             return False, f"Verification error: {package_name}"
 
     if progress_callback:
@@ -859,12 +869,12 @@ def ensure_venv_packages_available() -> bool:
         True if venv packages are available, False otherwise.
     """
     if not venv_exists():
-        _log("Venv does not exist, cannot load packages", Qgis.Warning)
+        _log("Venv does not exist, cannot load packages", Qgis.MessageLevel.Warning)
         return False
 
     site_packages = get_venv_site_packages()
     if site_packages is None:
-        _log(f"Venv site-packages not found in: {VENV_DIR}", Qgis.Warning)
+        _log(f"Venv site-packages not found in: {VENV_DIR}", Qgis.MessageLevel.Warning)
         return False
 
     if site_packages not in sys.path:
@@ -903,7 +913,10 @@ def _patch_ee_module():
                 _log(f"Patched ee into {mod_name}")
 
     except ImportError as exc:
-        _log(f"Failed to import ee after venv injection: {exc}", Qgis.Warning)
+        _log(
+            f"Failed to import ee after venv injection: {exc}",
+            Qgis.MessageLevel.Warning,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1022,7 +1035,7 @@ def create_venv_and_install(
             if fallback and os.path.isfile(fallback):
                 _log(
                     f"Standalone download failed, using system Python: {fallback}",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
             else:
                 return False, f"Failed to download Python: {msg}"
@@ -1051,7 +1064,7 @@ def create_venv_and_install(
             # Non-fatal: fall back to pip for venv creation and installation
             _log(
                 f"uv download failed ({msg}), will use pip instead",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
         else:
             _log("uv package installer ready")
@@ -1182,7 +1195,7 @@ def authenticate_ee(
             return True, "Earth Engine authentication completed successfully"
         else:
             error = result.stderr or result.stdout or "Unknown error"
-            _log(f"EE authentication failed: {error[:200]}", Qgis.Warning)
+            _log(f"EE authentication failed: {error[:200]}", Qgis.MessageLevel.Warning)
             return False, f"Authentication failed: {error[:200]}"
 
     except subprocess.TimeoutExpired:
@@ -1222,9 +1235,9 @@ def cleanup_old_venv_directories() -> List[str]:
                     except Exception as e:
                         _log(
                             f"Failed to remove old venv {old_path}: {e}",
-                            Qgis.Warning,
+                            Qgis.MessageLevel.Warning,
                         )
     except Exception as e:
-        _log(f"Error scanning for old venvs: {e}", Qgis.Warning)
+        _log(f"Error scanning for old venvs: {e}", Qgis.MessageLevel.Warning)
 
     return removed

--- a/gee_data_catalogs/dialogs/catalog_dock.py
+++ b/gee_data_catalogs/dialogs/catalog_dock.py
@@ -206,10 +206,12 @@ class ThumbnailLoaderThread(QThread):
         try:
             import base64
             from urllib.request import urlopen, Request
+            from ..core._net import require_https
 
             # Add user agent to avoid 403 errors
+            require_https(self.thumbnail_url)
             req = Request(self.thumbnail_url, headers={"User-Agent": "Mozilla/5.0"})
-            with urlopen(req, timeout=10) as response:
+            with urlopen(req, timeout=10) as response:  # nosec B310
                 img_data = response.read()
                 img_base64 = base64.b64encode(img_data).decode("utf-8")
                 # Determine image format from URL
@@ -255,7 +257,7 @@ class ImageListLoaderThread(QThread):
                         date_str = datetime.fromtimestamp(timestamp / 1000).strftime(
                             "%Y-%m-%d"
                         )
-                    except Exception:
+                    except Exception:  # nosec B110
                         pass
 
                 images_info.append(
@@ -1088,7 +1090,7 @@ class TimeSeriesExportWorkerThread(QThread):
                     QgsMessageLog.logMessage(
                         f"Failed to export image {i + 1} ({label}): {error_msg}",
                         "GEE Data Catalogs",
-                        Qgis.Warning,
+                        Qgis.MessageLevel.Warning,
                     )
 
             self.finished.emit(successful_paths, failed_indices)
@@ -1269,7 +1271,7 @@ class TimeSeriesChartDialog(QWidget):
         super().__init__(parent)
         self.setWindowTitle("Time Series Chart")
         self.setMinimumSize(800, 600)
-        self.setWindowFlags(Qt.Window)
+        self.setWindowFlags(Qt.WindowType.Window)
 
         self._data = None
         self._multi_data = {}  # Dict mapping location_id to data
@@ -1290,7 +1292,7 @@ class TimeSeriesChartDialog(QWidget):
         band_layout = QHBoxLayout()
         band_layout.addWidget(QLabel("Select Bands:"))
         self.band_list = QListWidget()
-        self.band_list.setSelectionMode(QListWidget.MultiSelection)
+        self.band_list.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
         self.band_list.setMaximumHeight(100)
         self.band_list.itemSelectionChanged.connect(self._update_chart)
         band_layout.addWidget(self.band_list)
@@ -1659,7 +1661,7 @@ class TimeSeriesChartDialog(QWidget):
         if self._has_matplotlib and self._multi_data:
             try:
                 self.figure.autofmt_xdate(rotation=45)
-            except Exception:
+            except Exception:  # nosec B110
                 pass
 
         self.figure.tight_layout()
@@ -1683,11 +1685,14 @@ class TimeSeriesChartDialog(QWidget):
         metadata = self._data.get("metadata", {})
         asset_id = metadata.get("asset_id", "").split("/")[-1]
 
-        # Generate random colors for each band
-        random.seed(42)  # Consistent colors across updates
-        colors = []
-        for _ in range(len(selected_bands)):
-            colors.append((random.random(), random.random(), random.random()))
+        # Generate visually distinct, deterministic colors for each band.
+        # random is seeded with a constant; this is for visualization only,
+        # not for any security or cryptographic purpose.
+        random.seed(42)
+        colors = [
+            (random.random(), random.random(), random.random())  # nosec B311
+            for _ in range(len(selected_bands))
+        ]
 
         # Check if stacked (subplots) mode
         if self.stack_lines_check.isChecked() and len(selected_bands) > 1:
@@ -2251,7 +2256,7 @@ class PixelTimeSeriesMapTool:
             def __init__(self, canvas, callback):
                 super().__init__(canvas)
                 self.callback = callback
-                self.setCursor(Qt.CrossCursor)
+                self.setCursor(Qt.CursorShape.CrossCursor)
 
             def canvasReleaseEvent(self, event):
                 # Get click coordinates
@@ -2307,7 +2312,7 @@ class InspectorMapTool:
             def __init__(self, canvas, callback):
                 super().__init__(canvas)
                 self.callback = callback
-                self.setCursor(Qt.CrossCursor)
+                self.setCursor(Qt.CursorShape.CrossCursor)
 
             def canvasReleaseEvent(self, event):
                 # Get click coordinates
@@ -2401,7 +2406,9 @@ class CatalogDockWidget(QDockWidget):
         self._pixel_locations = []  # List of (lon, lat, id) tuples
         self._location_counter = 0  # Counter for unique location IDs
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
         self.setMinimumWidth(380)
 
         self._setup_ui()
@@ -2523,7 +2530,7 @@ class CatalogDockWidget(QDockWidget):
             QgsMessageLog.logMessage(
                 f"Error getting map extent in WGS84: {e}",
                 "GEE Data Catalogs",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return None
 
@@ -2725,7 +2732,7 @@ class CatalogDockWidget(QDockWidget):
             def _showRubberBand(self):
                 if self.rubberBand is None:
                     self.rubberBand = QgsRubberBand(
-                        self.canvas, QgsWkbTypes.PolygonGeometry
+                        self.canvas, QgsWkbTypes.GeometryType.PolygonGeometry
                     )
                     self.rubberBand.setColor(QColor(255, 0, 0, 50))  # Light red fill
                     self.rubberBand.setStrokeColor(
@@ -2733,7 +2740,7 @@ class CatalogDockWidget(QDockWidget):
                     )  # Red outline
                     self.rubberBand.setWidth(2)
 
-                self.rubberBand.reset(QgsWkbTypes.PolygonGeometry)
+                self.rubberBand.reset(QgsWkbTypes.GeometryType.PolygonGeometry)
                 if self.startPoint and self.endPoint:
                     point1 = QgsPointXY(self.startPoint.x(), self.startPoint.y())
                     point2 = QgsPointXY(self.endPoint.x(), self.startPoint.y())
@@ -2822,7 +2829,7 @@ class CatalogDockWidget(QDockWidget):
             QgsMessageLog.logMessage(
                 f"Error drawing bounding box: {e}",
                 "GEE Data Catalogs",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
 
     def _clear_drawn_bbox_ts(self):
@@ -2878,7 +2885,7 @@ class CatalogDockWidget(QDockWidget):
         layout.addLayout(source_layout)
 
         # Splitter for tree and details
-        splitter = QSplitter(Qt.Vertical)
+        splitter = QSplitter(Qt.Orientation.Vertical)
         layout.addWidget(splitter)
 
         # Category tree
@@ -2976,7 +2983,7 @@ class CatalogDockWidget(QDockWidget):
         layout.addWidget(search_group)
 
         # Splitter for results and details
-        splitter = QSplitter(Qt.Vertical)
+        splitter = QSplitter(Qt.Orientation.Vertical)
         layout.addWidget(splitter)
 
         # Results
@@ -3273,11 +3280,11 @@ class CatalogDockWidget(QDockWidget):
         # Current time label
         self.ts_current_label = QLabel("No time series loaded")
         self.ts_current_label.setStyleSheet("font-weight: bold; font-size: 12px;")
-        self.ts_current_label.setAlignment(Qt.AlignCenter)
+        self.ts_current_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         slider_layout.addWidget(self.ts_current_label)
 
         # Time slider
-        self.ts_time_slider = QSlider(Qt.Horizontal)
+        self.ts_time_slider = QSlider(Qt.Orientation.Horizontal)
         self.ts_time_slider.setMinimum(0)
         self.ts_time_slider.setMaximum(0)
         self.ts_time_slider.setValue(0)
@@ -3707,7 +3714,9 @@ class CatalogDockWidget(QDockWidget):
 
         # Image list (for individual mode)
         self.image_list_widget = QListWidget()
-        self.image_list_widget.setSelectionMode(QListWidget.ExtendedSelection)
+        self.image_list_widget.setSelectionMode(
+            QListWidget.SelectionMode.ExtendedSelection
+        )
         self.image_list_widget.setMaximumHeight(150)
         self.image_list_widget.setVisible(False)
         image_layout.addWidget(self.image_list_widget)
@@ -3803,7 +3812,7 @@ class CatalogDockWidget(QDockWidget):
         layout.addWidget(instructions)
 
         # Create splitter for code input and output
-        code_splitter = QSplitter(Qt.Vertical)
+        code_splitter = QSplitter(Qt.Orientation.Vertical)
 
         # Code input
         self.code_input = QPlainTextEdit()
@@ -4007,6 +4016,7 @@ class CatalogDockWidget(QDockWidget):
         import time
         from urllib.request import urlopen, Request
         from urllib.error import URLError
+        from ..core._net import require_https
 
         # Cache file path
         cache_dir = os.path.join(tempfile.gettempdir(), "gee_data_catalogs")
@@ -4022,21 +4032,22 @@ class CatalogDockWidget(QDockWidget):
                         data = json.load(f)
                         self._js_code_cache = self._parse_js_code_data(data)
                         return self._js_code_cache
-        except Exception:
+        except Exception:  # nosec B110
             pass
 
         # Download from GitHub
         url = "https://github.com/opengeos/datasets/releases/download/gee/f.json"
         try:
+            require_https(url)
             req = Request(url, headers={"User-Agent": "Mozilla/5.0"})
-            with urlopen(req, timeout=30) as response:
+            with urlopen(req, timeout=30) as response:  # nosec B310
                 data = json.loads(response.read().decode("utf-8"))
 
                 # Save to cache file
                 try:
                     with open(cache_file, "w", encoding="utf-8") as f:
                         json.dump(data, f)
-                except Exception:
+                except Exception:  # nosec B110
                     pass
 
                 self._js_code_cache = self._parse_js_code_data(data)
@@ -4045,7 +4056,7 @@ class CatalogDockWidget(QDockWidget):
             QgsMessageLog.logMessage(
                 f"Failed to load JavaScript code cache: {e}",
                 "GEE Data Catalogs",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             self._js_code_cache = {}
             return self._js_code_cache
@@ -4139,7 +4150,7 @@ class CatalogDockWidget(QDockWidget):
             QgsMessageLog.logMessage(
                 f"Failed to run JavaScript code for {asset_id}: {e}",
                 "GEE Data Catalogs",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return False
 
@@ -4182,7 +4193,7 @@ class CatalogDockWidget(QDockWidget):
                         clipboard = QApplication.clipboard()
                         clipboard.setText(py_code)
                         return
-                except Exception:
+                except Exception:  # nosec B110
                     # If conversion fails, fall through to generate basic snippet
                     pass
 
@@ -4260,7 +4271,7 @@ class CatalogDockWidget(QDockWidget):
             QgsMessageLog.logMessage(
                 f"Failed to copy snippet for {asset_id}: {e}",
                 "GEE Data Catalogs",
-                Qgis.Info,
+                Qgis.MessageLevel.Info,
             )
 
     def _execute_code_internal(self, code):
@@ -4322,7 +4333,11 @@ class CatalogDockWidget(QDockWidget):
         namespace["Map"] = QGISMap
 
         try:
-            exec(code, namespace)
+            # User-authored Earth Engine code from the in-plugin code console.
+            # Executing it is the feature: see the docstring of the surrounding
+            # method. The namespace is pre-populated with geemap/Map for the
+            # user's convenience and is not derived from untrusted input.
+            exec(code, namespace)  # nosec B102
         finally:
             # Restore original modules
             if original_geemap is not None:
@@ -4339,7 +4354,7 @@ class CatalogDockWidget(QDockWidget):
         if not code.strip():
             return
 
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         try:
             import sys
@@ -4396,8 +4411,11 @@ class CatalogDockWidget(QDockWidget):
             namespace["Map"] = QGISMap
 
             try:
-                # Execute the code
-                exec(code, namespace)
+                # Execute user-authored Earth Engine code from the code console.
+                # Running it is the feature: the user typed/pasted the code into
+                # the dock and clicked Run. The namespace is pre-populated with
+                # geemap/Map and is not derived from untrusted input.
+                exec(code, namespace)  # nosec B102
                 self._show_success("Code executed successfully!")
             finally:
                 # Restore original modules
@@ -4909,10 +4927,12 @@ class CatalogDockWidget(QDockWidget):
         canvas = self.iface.mapCanvas()
 
         # Create a rubber band for visual feedback
-        self._export_rubber_band = QgsRubberBand(canvas, QgsWkbTypes.PolygonGeometry)
-        self._export_rubber_band.setColor(Qt.red)
+        self._export_rubber_band = QgsRubberBand(
+            canvas, QgsWkbTypes.GeometryType.PolygonGeometry
+        )
+        self._export_rubber_band.setColor(Qt.GlobalColor.red)
         self._export_rubber_band.setWidth(2)
-        self._export_rubber_band.setFillColor(Qt.transparent)
+        self._export_rubber_band.setFillColor(Qt.GlobalColor.transparent)
 
         # Store start point
         self._export_bbox_start = None
@@ -4928,7 +4948,9 @@ class CatalogDockWidget(QDockWidget):
             def canvasPressEvent(tool_self, event):
                 tool_self.start_point = tool_self.toMapCoordinates(event.pos())
                 tool_self.is_drawing = True
-                tool_self.dock._export_rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+                tool_self.dock._export_rubber_band.reset(
+                    QgsWkbTypes.GeometryType.PolygonGeometry
+                )
 
             def canvasMoveEvent(tool_self, event):
                 if not tool_self.is_drawing:
@@ -5089,9 +5111,9 @@ class CatalogDockWidget(QDockWidget):
             self,
             "Export Complete",
             f"Export successful!\n{output_path}\n\nAdd layer to map?",
-            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             layer_name = os.path.splitext(os.path.basename(output_path))[0]
             if output_path.lower().endswith(".tif"):
                 from qgis.core import QgsRasterLayer
@@ -5287,9 +5309,9 @@ class CatalogDockWidget(QDockWidget):
             self,
             "Export Complete",
             f"Image exported successfully to:\n{output_path}\n\nAdd layer to map?",
-            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             from qgis.core import QgsRasterLayer
 
             layer_name = os.path.splitext(os.path.basename(output_path))[0]
@@ -5394,9 +5416,9 @@ class CatalogDockWidget(QDockWidget):
             self,
             "Export Complete",
             f"Features exported successfully to:\n{output_path}\n\nAdd layer to map?",
-            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             from qgis.core import QgsVectorLayer
 
             layer = QgsVectorLayer(
@@ -5501,7 +5523,7 @@ class CatalogDockWidget(QDockWidget):
                             source_display,
                         ]
                     )
-                    ds_item.setData(0, Qt.UserRole, dataset)
+                    ds_item.setData(0, Qt.ItemDataRole.UserRole, dataset)
                     ds_item.setToolTip(0, dataset.get("id", ""))
                     cat_item.addChild(ds_item)
 
@@ -5523,7 +5545,7 @@ class CatalogDockWidget(QDockWidget):
 
             for j in range(cat_item.childCount()):
                 ds_item = cat_item.child(j)
-                dataset = ds_item.data(0, Qt.UserRole)
+                dataset = ds_item.data(0, Qt.ItemDataRole.UserRole)
 
                 if source is None or dataset.get("source") == source:
                     ds_item.setHidden(False)
@@ -5550,7 +5572,7 @@ class CatalogDockWidget(QDockWidget):
 
     def _on_dataset_selected(self, item, _column):
         """Handle dataset selection in tree."""
-        dataset = item.data(0, Qt.UserRole)
+        dataset = item.data(0, Qt.ItemDataRole.UserRole)
         if dataset:
             self._selected_dataset = dataset
             self._show_dataset_info(dataset)
@@ -5571,7 +5593,7 @@ class CatalogDockWidget(QDockWidget):
 
     def _on_dataset_double_clicked(self, item, _column):
         """Handle double-click on dataset."""
-        dataset = item.data(0, Qt.UserRole)
+        dataset = item.data(0, Qt.ItemDataRole.UserRole)
         if dataset:
             self._add_dataset_to_map(dataset)
 
@@ -5691,16 +5713,18 @@ class CatalogDockWidget(QDockWidget):
             try:
                 import base64
                 from urllib.request import urlopen, Request
+                from ..core._net import require_https
 
+                require_https(thumbnail_url)
                 req = Request(thumbnail_url, headers={"User-Agent": "Mozilla/5.0"})
-                with urlopen(req, timeout=5) as response:
+                with urlopen(req, timeout=5) as response:  # nosec B310
                     img_data = response.read()
                     img_base64 = base64.b64encode(img_data).decode("utf-8")
                     img_format = "png" if thumbnail_url.endswith(".png") else "jpeg"
                     info_lines.append(
                         f"<br><img src='data:image/{img_format};base64,{img_base64}' width='300' style='border: 1px solid #ccc; border-radius: 4px;'><br>"
                     )
-            except Exception:
+            except Exception:  # nosec B110
                 # If thumbnail loading fails, just skip it
                 pass
 
@@ -5786,7 +5810,7 @@ class CatalogDockWidget(QDockWidget):
                             break
                         except ValueError:
                             continue
-                except Exception:
+                except Exception:  # nosec B110
                     pass
 
             if end_date:
@@ -5800,7 +5824,7 @@ class CatalogDockWidget(QDockWidget):
                             break
                         except ValueError:
                             continue
-                except Exception:
+                except Exception:  # nosec B110
                     pass
 
             # Generate and copy time series Python code snippet to clipboard
@@ -5892,7 +5916,7 @@ for f in data['features']:
             self._show_error("Dataset has no ID")
             return
 
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         try:
             self._show_progress(f"Loading {asset_id}...")
@@ -5948,7 +5972,7 @@ for f in data['features']:
                 QgsMessageLog.logMessage(
                     f"Loading as {catalog_type} failed for {asset_id}: {type_err}",
                     "GEE Data Catalogs",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
 
             # If loading based on catalog type failed, auto-detect
@@ -6010,7 +6034,7 @@ for f in data['features']:
                         dataset.get("source", "unknown"),
                     ]
                 )
-                item.setData(0, Qt.UserRole, dataset)
+                item.setData(0, Qt.ItemDataRole.UserRole, dataset)
                 item.setToolTip(0, dataset.get("id", ""))
                 self.search_results.addTopLevelItem(item)
 
@@ -6024,7 +6048,7 @@ for f in data['features']:
 
     def _on_search_result_selected(self, item, _column):
         """Handle search result selection."""
-        dataset = item.data(0, Qt.UserRole)
+        dataset = item.data(0, Qt.ItemDataRole.UserRole)
         if dataset:
             self._selected_dataset = dataset
             self._show_search_dataset_info(dataset)
@@ -6039,7 +6063,7 @@ for f in data['features']:
 
     def _on_search_result_double_clicked(self, item, _column):
         """Handle double-click on search result."""
-        dataset = item.data(0, Qt.UserRole)
+        dataset = item.data(0, Qt.ItemDataRole.UserRole)
         if dataset:
             self._add_dataset_to_map(dataset)
 
@@ -6047,7 +6071,7 @@ for f in data['features']:
         """Add selected search result to map."""
         items = self.search_results.selectedItems()
         if items:
-            dataset = items[0].data(0, Qt.UserRole)
+            dataset = items[0].data(0, Qt.ItemDataRole.UserRole)
             if dataset:
                 self._add_dataset_to_map(dataset)
 
@@ -6055,7 +6079,7 @@ for f in data['features']:
         """Configure and add selected search result."""
         items = self.search_results.selectedItems()
         if items:
-            dataset = items[0].data(0, Qt.UserRole)
+            dataset = items[0].data(0, Qt.ItemDataRole.UserRole)
             if dataset:
                 # Populate the load tab with dataset info
                 self.dataset_id_input.setText(dataset.get("id", ""))
@@ -6067,7 +6091,7 @@ for f in data['features']:
         """Configure time series from selected search result."""
         items = self.search_results.selectedItems()
         if items:
-            dataset = items[0].data(0, Qt.UserRole)
+            dataset = items[0].data(0, Qt.ItemDataRole.UserRole)
             if dataset:
                 # Store as selected dataset and use common method
                 self._selected_dataset = dataset
@@ -6084,7 +6108,7 @@ for f in data['features']:
             QMessageBox.warning(self, "Warning", "Please enter an asset ID.")
             return
 
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
         self.fetch_images_btn.setEnabled(False)
 
         try:
@@ -6144,7 +6168,7 @@ for f in data['features']:
         self.image_list_widget.clear()
         for img in images_info:
             item = QListWidgetItem(f"{img['date']} - {img['id'].split('/')[-1]}")
-            item.setData(Qt.UserRole, img)
+            item.setData(Qt.ItemDataRole.UserRole, img)
             self.image_list_widget.addItem(item)
 
         self._show_success(f"Found {len(images_info)} images")
@@ -6170,7 +6194,7 @@ for f in data['features']:
             QMessageBox.warning(self, "Warning", "Please enter an asset ID.")
             return
 
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         try:
             self._show_progress(f"Loading {asset_id}...")
@@ -6188,7 +6212,7 @@ for f in data['features']:
                 # Load each selected image
                 vis_params = self._build_vis_params()
                 for item in selected_items:
-                    img_info = item.data(Qt.UserRole)
+                    img_info = item.data(Qt.ItemDataRole.UserRole)
                     image_id = img_info["id"]
                     name = f"{self.layer_name_input.text().strip() or asset_id.split('/')[-1]} - {img_info['date']}"
 
@@ -6223,7 +6247,7 @@ for f in data['features']:
                         try:
                             ee_object = loader_fn(asset_id)
                             break
-                        except Exception:
+                        except Exception:  # nosec B112
                             continue
                     else:
                         raise ValueError(f"Could not load asset: {asset_id}")
@@ -6420,7 +6444,7 @@ for f in data['features']:
                 # Preview only selected items
                 selected_images = []
                 for item in selected_items:
-                    img_info = item.data(Qt.UserRole)
+                    img_info = item.data(Qt.ItemDataRole.UserRole)
                     if img_info:
                         selected_images.append(img_info)
                 self._show_progress(
@@ -6431,7 +6455,7 @@ for f in data['features']:
                 selected_images = []
                 for i in range(self.image_list_widget.count()):
                     item = self.image_list_widget.item(i)
-                    img_info = item.data(Qt.UserRole)
+                    img_info = item.data(Qt.ItemDataRole.UserRole)
                     if img_info:
                         selected_images.append(img_info)
                 self._show_progress(
@@ -6719,7 +6743,7 @@ for f in data['features']:
         if not code.strip():
             return
 
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         try:
             import sys
@@ -6776,8 +6800,11 @@ for f in data['features']:
             namespace["Map"] = QGISMap
 
             try:
-                # Execute the code
-                exec(code, namespace)
+                # Execute user-authored Earth Engine code from the code console.
+                # Running it is the feature: the user typed/pasted the code into
+                # the dock and clicked Run. The namespace is pre-populated with
+                # geemap/Map and is not derived from untrusted input.
+                exec(code, namespace)  # nosec B102
 
                 self.code_output.setPlainText("✓ Code executed successfully!")
                 self.code_output.setStyleSheet("color: green;")
@@ -6889,7 +6916,7 @@ for f in data['features']:
 
                         canvas.setExtent(extent)
                         canvas.refresh()
-                except Exception:
+                except Exception:  # nosec B110
                     # If centering fails, silently ignore
                     pass
 
@@ -7297,7 +7324,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
                 error_item = QTreeWidgetItem(
                     ["Error", data.get("error", "Unknown error")]
                 )
-                error_item.setForeground(1, Qt.red)
+                error_item.setForeground(1, Qt.GlobalColor.red)
                 layer_item.addChild(error_item)
 
             elif data.get("type") in ["Image", "ImageCollection"]:
@@ -7436,12 +7463,12 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
 
         # Generate a color for this marker (use consistent colors based on ID)
         random.seed(location_id)
-        r = random.randint(100, 255)
-        g = random.randint(50, 200)
-        b = random.randint(50, 200)
+        r = random.randint(100, 255)  # nosec B311
+        g = random.randint(50, 200)  # nosec B311
+        b = random.randint(50, 200)  # nosec B311
 
         # Create marker as a point rubber band
-        marker = QgsRubberBand(canvas, QgsWkbTypes.PointGeometry)
+        marker = QgsRubberBand(canvas, QgsWkbTypes.GeometryType.PointGeometry)
         marker.setColor(QColor(r, g, b, 220))
         marker.setFillColor(QColor(r, g, b, 180))
         marker.setWidth(2)
@@ -7541,7 +7568,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
             f"Extracting time series data for location {location_id}..."
         )
         self.pixel_status_label.setStyleSheet("color: #2980b9; font-size: 10px;")
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         # Store current location_id for the callback
         self._current_extraction_location_id = location_id
@@ -7730,7 +7757,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         # Stop any existing playback
         self._stop_timeseries_playback()
 
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
         self.ts_create_btn.setEnabled(False)
         self.ts_export_btn.setEnabled(False)
 
@@ -8043,7 +8070,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         QgsMessageLog.logMessage(
             f"Exported image {index + 1}: {os.path.basename(output_path)}",
             "GEE Data Catalogs",
-            Qgis.Info,
+            Qgis.MessageLevel.Info,
         )
 
     def _on_ts_image_failed(self, index: int, error_message: str):
@@ -8061,7 +8088,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         QgsMessageLog.logMessage(
             f"Failed to export {label}: {error_message}",
             "GEE Data Catalogs",
-            Qgis.Warning,
+            Qgis.MessageLevel.Warning,
         )
 
     def _on_ts_export_finished(self, successful_paths: list, failed_indices: list):
@@ -8122,7 +8149,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         QgsMessageLog.logMessage(
             f"Time series export error: {error_message}",
             "GEE Data Catalogs",
-            Qgis.Critical,
+            Qgis.MessageLevel.Critical,
         )
         self._show_error(f"Export failed:\n{error_message}")
 
@@ -8409,7 +8436,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
             QMessageBox.warning(self, "Warning", "Please enter an asset ID.")
             return
 
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         try:
             start_date = self.ts_start_date.date().toString("yyyy-MM-dd")

--- a/gee_data_catalogs/dialogs/dependency_dialog.py
+++ b/gee_data_catalogs/dialogs/dependency_dialog.py
@@ -40,7 +40,9 @@ class DependencyDockWidget(QDockWidget):
         self._auth_worker = None
         self._has_emitted_success = False
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
         self._setup_ui()
         self._refresh_deps_status()
 
@@ -58,7 +60,7 @@ class DependencyDockWidget(QDockWidget):
         header_font.setPointSize(12)
         header_font.setBold(True)
         header.setFont(header_font)
-        header.setAlignment(Qt.AlignCenter)
+        header.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header)
 
         # Info label
@@ -71,7 +73,7 @@ class DependencyDockWidget(QDockWidget):
             "Your QGIS Python environment will not be modified."
         )
         info.setWordWrap(True)
-        info.setTextFormat(Qt.RichText)
+        info.setTextFormat(Qt.TextFormat.RichText)
         layout.addWidget(info)
 
         # Package status group

--- a/gee_data_catalogs/dialogs/settings_dock.py
+++ b/gee_data_catalogs/dialogs/settings_dock.py
@@ -44,7 +44,9 @@ class SettingsDockWidget(QDockWidget):
         self.iface = iface
         self.settings = QSettings()
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         self._setup_ui()
         self._load_settings()
@@ -65,7 +67,7 @@ class SettingsDockWidget(QDockWidget):
         header_font.setPointSize(12)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header_label)
 
         # Tab widget for organized settings
@@ -427,11 +429,11 @@ class SettingsDockWidget(QDockWidget):
             self,
             "Reset Settings",
             "Are you sure you want to reset all settings to defaults?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         # General

--- a/gee_data_catalogs/dialogs/update_checker.py
+++ b/gee_data_catalogs/dialogs/update_checker.py
@@ -13,6 +13,8 @@ import zipfile
 from urllib.request import urlopen, urlretrieve
 from urllib.error import URLError, HTTPError
 
+from ..core._net import require_https
+
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
 from qgis.PyQt.QtWidgets import (
     QDialog,
@@ -45,7 +47,8 @@ class VersionCheckWorker(QThread):
     def run(self):
         """Fetch the latest metadata from GitHub."""
         try:
-            with urlopen(METADATA_URL, timeout=15) as response:
+            require_https(METADATA_URL)
+            with urlopen(METADATA_URL, timeout=15) as response:  # nosec B310
                 content = response.read().decode("utf-8")
 
             # Parse version from metadata
@@ -106,7 +109,8 @@ class DownloadWorker(QThread):
                     percent = min(int((downloaded / total_size) * 50), 50)
                     self.progress.emit(10 + percent, "Downloading...")
 
-            urlretrieve(ZIP_URL, zip_path, reporthook)
+            require_https(ZIP_URL)
+            urlretrieve(ZIP_URL, zip_path, reporthook)  # nosec B310
 
             self.progress.emit(60, "Extracting files...")
 
@@ -230,7 +234,7 @@ class UpdateCheckerDialog(QDialog):
         header_font.setPointSize(14)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header_label)
 
         # Version info group
@@ -275,7 +279,7 @@ class UpdateCheckerDialog(QDialog):
         # Progress label
         self.progress_label = QLabel("")
         self.progress_label.setVisible(False)
-        self.progress_label.setAlignment(Qt.AlignCenter)
+        self.progress_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.progress_label)
 
         # Buttons
@@ -304,7 +308,7 @@ class UpdateCheckerDialog(QDialog):
         )
         info_label.setWordWrap(True)
         info_label.setOpenExternalLinks(True)
-        info_label.setAlignment(Qt.AlignCenter)
+        info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(info_label)
 
     def check_for_updates(self):
@@ -395,11 +399,11 @@ class UpdateCheckerDialog(QDialog):
             f"This will download and install version {self.latest_version}.\n\n"
             "IMPORTANT: You will need to restart QGIS after the update completes.\n\n"
             "Do you want to continue?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         self.check_btn.setEnabled(False)
@@ -480,10 +484,10 @@ class UpdateCheckerDialog(QDialog):
                 self,
                 "Download in Progress",
                 "A download is in progress. Are you sure you want to cancel?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
-            if reply != QMessageBox.Yes:
+            if reply != QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
             self.download_worker.terminate()

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -268,7 +268,9 @@ class GeeDataCatalogs:
 
             self._deps_dock = DependencyDockWidget(self.iface, self.iface.mainWindow())
             self._deps_dock.setObjectName("GeeDataCatalogsDeps")
-            self.iface.addDockWidget(Qt.RightDockWidgetArea, self._deps_dock)
+            self.iface.addDockWidget(
+                Qt.DockWidgetArea.RightDockWidgetArea, self._deps_dock
+            )
             self._deps_dock.install_succeeded.connect(self._on_deps_installed)
             self._deps_dock.auth_succeeded.connect(self._on_auth_completed)
 
@@ -341,7 +343,7 @@ class GeeDataCatalogs:
                     QgsMessageLog.logMessage(
                         f"Auto-initializing Earth Engine with project from {project_source}: {project_id}",
                         "GEE Data Catalogs",
-                        Qgis.Info,
+                        Qgis.MessageLevel.Info,
                     )
                     initialize_ee(project=project_id)
                 except Exception as exc:
@@ -350,7 +352,7 @@ class GeeDataCatalogs:
                     QgsMessageLog.logMessage(
                         f"Auto-init EE failed: {exc}",
                         "GEE Data Catalogs",
-                        Qgis.Warning,
+                        Qgis.MessageLevel.Warning,
                     )
         except ImportError:
             # Dependencies not yet available - user can manually initialize
@@ -447,7 +449,7 @@ class GeeDataCatalogs:
                         QgsMessageLog.logMessage(
                             f"Initializing Earth Engine for project layers (using project from {project_source}): {project_id}",
                             "GEE Data Catalogs",
-                            Qgis.Info,
+                            Qgis.MessageLevel.Info,
                         )
                         init_ee_core(project=project_id)
                         initialized = True
@@ -455,7 +457,7 @@ class GeeDataCatalogs:
                         QgsMessageLog.logMessage(
                             f"EE init for project layers failed: {exc}",
                             "GEE Data Catalogs",
-                            Qgis.Warning,
+                            Qgis.MessageLevel.Warning,
                         )
 
                 if not initialized:
@@ -568,7 +570,9 @@ class GeeDataCatalogs:
             self._catalog_dock.visibilityChanged.connect(
                 self._on_catalog_visibility_changed
             )
-            self.iface.addDockWidget(Qt.RightDockWidgetArea, self._catalog_dock)
+            self.iface.addDockWidget(
+                Qt.DockWidgetArea.RightDockWidgetArea, self._catalog_dock
+            )
             self._catalog_dock.show()
             self._catalog_dock.raise_()
         except Exception as e:
@@ -610,7 +614,9 @@ class GeeDataCatalogs:
                 self._on_settings_visibility_changed
             )
             self._settings_dock.settings_saved.connect(self._try_auto_init_ee)
-            self.iface.addDockWidget(Qt.RightDockWidgetArea, self._settings_dock)
+            self.iface.addDockWidget(
+                Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
+            )
             self._settings_dock.show()
             self._settings_dock.raise_()
         except Exception as e:
@@ -715,7 +721,7 @@ Google Earth Engine data catalogs directly in QGIS.</p>
 
         try:
             dialog = UpdateCheckerDialog(self.plugin_dir, self.iface.mainWindow())
-            dialog.exec_()
+            dialog.exec()
         except Exception as e:
             QMessageBox.critical(
                 self.iface.mainWindow(),

--- a/gee_data_catalogs/metadata.txt
+++ b/gee_data_catalogs/metadata.txt
@@ -1,8 +1,9 @@
 [general]
 name=Earth Engine Data Catalogs
 qgisMinimumVersion=3.28
+qgisMaximumVersion=4.99
 description=Browse, search, and load Google Earth Engine data catalogs directly in QGIS.
-version=0.9.1
+version=0.10.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -36,6 +37,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.10.0
+        - Compatible with QGIS 4.0 (Qt6) while keeping QGIS 3.28+ (Qt5) support
     0.9.1
         - Allow main panel to open when standalone Python is absent
     0.9.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+"""Shared pytest fixtures.
+
+Stubs the ``qgis`` package so the plugin's modules can be imported without a
+running QGIS instance. The stub reproduces the real ``qgis.PyQt`` shim
+behavior on Qt6: it re-exports ``QAction``, ``QActionGroup`` and ``QShortcut``
+from ``PyQt6.QtGui`` under ``qgis.PyQt.QtWidgets`` (they moved out of
+``QtWidgets`` in Qt6).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import PyQt6.QtCore
+import PyQt6.QtGui
+import PyQt6.QtNetwork
+import PyQt6.QtWidgets
+
+
+def _install_qgis_stub() -> None:
+    qgis = types.ModuleType("qgis")
+    qgis.__path__ = []
+    sys.modules["qgis"] = qgis
+
+    qgis_pyqt = types.ModuleType("qgis.PyQt")
+    qgis_pyqt.__path__ = []
+    sys.modules["qgis.PyQt"] = qgis_pyqt
+    qgis.PyQt = qgis_pyqt
+
+    pyqt_submodules = {
+        "QtCore": PyQt6.QtCore,
+        "QtGui": PyQt6.QtGui,
+        "QtNetwork": PyQt6.QtNetwork,
+        "QtWidgets": PyQt6.QtWidgets,
+    }
+    for name, real in pyqt_submodules.items():
+        alias = types.ModuleType(f"qgis.PyQt.{name}")
+        for attr in dir(real):
+            if not attr.startswith("_"):
+                setattr(alias, attr, getattr(real, attr))
+        sys.modules[f"qgis.PyQt.{name}"] = alias
+        setattr(qgis_pyqt, name, alias)
+
+    # Qt6: QAction, QActionGroup, and QShortcut live in QtGui. The real
+    # qgis.PyQt.QtWidgets shim re-exports them, so mirror that here.
+    qtwidgets_alias = sys.modules["qgis.PyQt.QtWidgets"]
+    for attr in ("QAction", "QActionGroup", "QShortcut"):
+        setattr(qtwidgets_alias, attr, getattr(PyQt6.QtGui, attr))
+
+    for submodule in ("QtSvg", "QtWebEngineWidgets"):
+        alias = MagicMock()
+        sys.modules[f"qgis.PyQt.{submodule}"] = alias
+        setattr(qgis_pyqt, submodule, alias)
+
+    for name in ("core", "gui", "utils"):
+        stub = MagicMock()
+        stub.__spec__ = None
+        sys.modules[f"qgis.{name}"] = stub
+        setattr(qgis, name, stub)
+
+
+_install_qgis_stub()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,16 +5,28 @@ running QGIS instance. The stub reproduces the real ``qgis.PyQt`` shim
 behavior on Qt6: it re-exports ``QAction``, ``QActionGroup`` and ``QShortcut``
 from ``PyQt6.QtGui`` under ``qgis.PyQt.QtWidgets`` (they moved out of
 ``QtWidgets`` in Qt6).
+
+Two safety nets:
+- If PyQt6 is not installed (e.g. a PyQt5/QGIS 3.x dev shell), skip the entire
+  test module at collection time rather than crashing on import.
+- If a real ``qgis`` package is importable (someone is running pytest inside
+  a real QGIS/PyQGIS env), do nothing. Real bindings beat a stub.
 """
 
+import importlib.util
 import sys
 import types
 from unittest.mock import MagicMock
 
-import PyQt6.QtCore
-import PyQt6.QtGui
-import PyQt6.QtNetwork
-import PyQt6.QtWidgets
+import pytest
+
+try:
+    import PyQt6.QtCore
+    import PyQt6.QtGui
+    import PyQt6.QtNetwork
+    import PyQt6.QtWidgets
+except ImportError as exc:
+    pytest.skip(f"PyQt6 is required for these tests: {exc}", allow_module_level=True)
 
 
 def _install_qgis_stub() -> None:
@@ -59,4 +71,7 @@ def _install_qgis_stub() -> None:
         setattr(qgis, name, stub)
 
 
-_install_qgis_stub()
+# Only install the stub when no real qgis bindings are available; running
+# pytest inside a real QGIS/PyQGIS environment must use the real bindings.
+if importlib.util.find_spec("qgis") is None:
+    _install_qgis_stub()

--- a/tests/test_pyqt6_imports.py
+++ b/tests/test_pyqt6_imports.py
@@ -1,0 +1,54 @@
+"""Import-smoke tests that verify every plugin module loads under PyQt6.
+
+This catches short-form Qt enum regressions (for example ``Qt.AlignCenter``
+instead of ``Qt.AlignmentFlag.AlignCenter``) which raise ``AttributeError`` in
+PyQt6 during class-body evaluation.
+
+The plugin package is auto-discovered: the first sibling directory of
+``tests/`` that contains a ``metadata.txt`` is treated as the plugin root,
+so this file does not need to be edited per-plugin.
+"""
+
+import importlib
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _find_plugin_root() -> pathlib.Path:
+    """Return the plugin package directory (the one with metadata.txt)."""
+    candidates = [
+        p.parent for p in REPO_ROOT.glob("*/metadata.txt") if p.parent.name != "tests"
+    ]
+    if not candidates:
+        raise RuntimeError(
+            "Could not locate a QGIS plugin package (no */metadata.txt found "
+            f"under {REPO_ROOT})."
+        )
+    if len(candidates) > 1:
+        raise RuntimeError(
+            f"Multiple plugin packages found under {REPO_ROOT}: {candidates}. "
+            "Set PLUGIN_ROOT explicitly in this file."
+        )
+    return candidates[0]
+
+
+PLUGIN_ROOT = _find_plugin_root()
+
+
+def _module_names():
+    """Yield dotted module names for every .py file under the plugin package."""
+    for path in sorted(PLUGIN_ROOT.rglob("*.py")):
+        rel = path.relative_to(PLUGIN_ROOT.parent).with_suffix("")
+        parts = rel.parts
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        yield ".".join(parts)
+
+
+@pytest.mark.parametrize("module_name", list(_module_names()))
+def test_module_imports_under_pyqt6(module_name):
+    """Each plugin module must import cleanly when qgis.PyQt maps to PyQt6."""
+    importlib.import_module(module_name)


### PR DESCRIPTION
## Summary

Make the plugin load on both QGIS 3.28+ (PyQt5) and QGIS 4.0 (PyQt6) from a single codebase, so it appears on the official "QGIS 4 Ready" plugin list (https://plugins.qgis.org/plugins/new_qgis_ready/) without breaking existing 3.x users.

- `metadata.txt`: bump to **0.10.0**, add `qgisMaximumVersion=4.99` (this is what flips the plugin onto the QGIS 4 Ready list; `supportsQt6` is no longer used).
- Fully qualify Qt enums (`Qt.AlignmentFlag.AlignCenter`, `Qt.CursorShape.WaitCursor`, `Qt.DockWidgetArea.LeftDockWidgetArea`, etc.) and QGIS core enums (`Qgis.MessageLevel.Info`, `QgsWkbTypes.GeometryType.PolygonGeometry`). These forms work on both PyQt5 ≥ 5.15 and PyQt6, so one source serves both.
- Replace `dialog.exec_()` with `dialog.exec()`.
- Add `tests/` with PyQt6 import-smoke tests that auto-discover the plugin package and import every `.py` file under it (15/15 pass under PyQt6).
- Resolve all Bandit findings (now `No issues identified.`):
  - `exec(code, namespace)` in the in-plugin code console: documented and suppressed (this is the feature; the user types/pastes their own GEE code).
  - `urlopen(...)`: new `gee_data_catalogs/core/_net.py::require_https()` helper rejects non-https schemes; called before each urlopen site, then suppressed.
  - `try/except/pass`, `try/except/continue`, and `random.*` for visualization color generation: documented and suppressed inline.
- Add `.github/workflows/ci.yml` with three jobs: pre-commit, Bandit (matches the security scan plugins.qgis.org runs on upload), and PyQt6 import-smoke matrix over Python 3.10-3.13 (with `libegl1`/`libgl1`/`libxkbcommon0`/`libdbus-1-3`/`libfontconfig1` apt-installed for `import PyQt6.QtGui`).
- Add Bandit hook to `.pre-commit-config.yaml`.

Migration guides followed:
- https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6
- https://plugins.qgis.org/docs/migrate-qgis4

## Test plan

Automated (CI):
- [x] `pre-commit run --all-files` clean (now includes Bandit)
- [x] `bandit -r gee_data_catalogs` clean
- [x] `pytest tests/ -v` 15/15 PyQt6 import-smoke tests pass
- [x] `python -m compileall gee_data_catalogs` clean under host PyQt5

Manual (please verify before merge):
- [ ] Install branch into QGIS 3.28+ (Qt5): toolbar action, dock panel opens on both Left and Right dock areas, catalog browse/search/filter, time-series chart, Inspector tool, code console (the suppressed `exec()` paths), settings dock, update checker dialog, dependency installer dialog, `QMessageBox` Yes/No confirms (especially settings reset and update install).
- [ ] Install branch into a QGIS 4.0 nightly (Qt6): repeat the same checks. Pay attention to dialog button labels (Yes/No), wait-cursor on long ops, dock area placement, RichText About panel rendering.