### PR TITLE
feat(ai): add GeoAgent-powered AI assistant dock

### DIFF
--- a/gee_data_catalogs/core/ee_utils.py
+++ b/gee_data_catalogs/core/ee_utils.py
@@ -27,6 +27,23 @@ _ee_initialized = False
 _ee_layer_registry = {}
 
 
+def _normalize_ee_asset_type(asset_type: str) -> str:
+    """Normalize Earth Engine asset type names from catalog/API metadata."""
+    normalized = str(asset_type or "").lower().replace("_", "").replace(" ", "")
+    if normalized in {"image", "eeimage"}:
+        return "Image"
+    if normalized in {"imagecollection", "eeimagecollection"}:
+        return "ImageCollection"
+    if normalized in {
+        "featurecollection",
+        "table",
+        "eefeaturecollection",
+        "bigquerytable",
+    }:
+        return "FeatureCollection"
+    return "Unknown"
+
+
 def is_ee_initialized() -> bool:
     """Check if Earth Engine has been initialized."""
     global _ee_initialized
@@ -536,6 +553,20 @@ def detect_asset_type(asset_id: str) -> str:
     """
     if ee is None:
         raise ImportError("Earth Engine API not available")
+
+    # Prefer asset metadata. It is much cheaper than evaluating Image/
+    # ImageCollection objects with getInfo(), and avoids long UI stalls.
+    try:
+        asset_info = ee.data.getAsset(asset_id)
+        metadata_type = _normalize_ee_asset_type(asset_info.get("type"))
+        if metadata_type != "Unknown":
+            return metadata_type
+    except Exception as metadata_err:
+        QgsMessageLog.logMessage(
+            f"Asset metadata lookup failed for {asset_id}: {metadata_err}",
+            "GEE Data Catalogs",
+            Qgis.MessageLevel.Info,
+        )
 
     # Try Image first
     try:

--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -25,6 +25,7 @@ VENV_DIR = os.path.join(CACHE_DIR, "venv")
 REQUIRED_PACKAGES = [
     ("earthengine-api", ">=1.4.0"),
     ("geemap", ""),
+    ("GeoAgent", "[providers]>=1.0.0"),
 ]
 
 
@@ -777,6 +778,8 @@ def _get_verification_code(package_name: str) -> str:
     """
     if package_name == "earthengine-api":
         return "import ee; print(ee.__version__)"
+    if package_name == "GeoAgent":
+        return "import geoagent; print(geoagent.__version__)"
     import_name = package_name.replace("-", "_")
     return f"import {import_name}"
 
@@ -938,10 +941,18 @@ def get_venv_status() -> Tuple[bool, str]:
     if site_packages is None:
         return False, "Virtual environment incomplete"
 
-    # Check for earthengine-api marker (the 'ee' package directory)
-    ee_dir = os.path.join(site_packages, "ee")
-    if not os.path.isdir(ee_dir):
-        return False, "earthengine-api not installed"
+    if site_packages not in sys.path:
+        sys.path.insert(0, site_packages)
+
+    missing = []
+    for package_name, _version_spec in REQUIRED_PACKAGES:
+        try:
+            importlib.metadata.version(package_name)
+        except importlib.metadata.PackageNotFoundError:
+            missing.append(package_name)
+
+    if missing:
+        return False, f"Missing packages: {', '.join(missing)}"
 
     return True, "Dependencies ready"
 

--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -941,15 +941,16 @@ def get_venv_status() -> Tuple[bool, str]:
     if site_packages is None:
         return False, "Virtual environment incomplete"
 
-    if site_packages not in sys.path:
-        sys.path.insert(0, site_packages)
+    installed_packages = {
+        (dist.metadata.get("Name") or "").lower()
+        for dist in importlib.metadata.distributions(path=[site_packages])
+    }
 
-    missing = []
-    for package_name, _version_spec in REQUIRED_PACKAGES:
-        try:
-            importlib.metadata.version(package_name)
-        except importlib.metadata.PackageNotFoundError:
-            missing.append(package_name)
+    missing = [
+        package_name
+        for package_name, _version_spec in REQUIRED_PACKAGES
+        if package_name.lower() not in installed_packages
+    ]
 
     if missing:
         return False, f"Missing packages: {', '.join(missing)}"

--- a/gee_data_catalogs/dialogs/catalog_dock.py
+++ b/gee_data_catalogs/dialogs/catalog_dock.py
@@ -8937,4 +8937,10 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         if self._timeseries_thread and self._timeseries_thread.isRunning():
             self._timeseries_thread.terminate()
             self._timeseries_thread.wait()
+
+        # Stop and wait for the AI assistant chat worker before deletion
+        ai_tab = getattr(self, "ai_assistant_tab", None)
+        if ai_tab is not None and hasattr(ai_tab, "shutdown"):
+            ai_tab.shutdown()
+
         event.accept()

--- a/gee_data_catalogs/dialogs/catalog_dock.py
+++ b/gee_data_catalogs/dialogs/catalog_dock.py
@@ -85,17 +85,102 @@ class PreviewInfoThread(QThread):
     def __init__(
         self,
         asset_id: str,
+        asset_type: str = None,
         use_date_filter: bool = False,
         start_date: str = None,
         end_date: str = None,
+        bbox: list = None,
+        cloud_cover: int = None,
+        cloud_property: str = None,
+        property_filters: list = None,
         selected_images: list = None,
     ):
         super().__init__()
         self.asset_id = asset_id
+        self.asset_type = asset_type
         self.use_date_filter = use_date_filter
         self.start_date = start_date
         self.end_date = end_date
+        self.bbox = bbox
+        self.cloud_cover = cloud_cover
+        self.cloud_property = cloud_property
+        self.property_filters = property_filters or []
         self.selected_images = selected_images  # List of {"id": ..., "date": ...}
+
+    def _apply_property_filters(self, collection):
+        """Apply parsed property filters to an Earth Engine collection."""
+        import ee
+
+        for prop_name, op, value in self.property_filters:
+            if op == "==":
+                collection = collection.filter(ee.Filter.eq(prop_name, value))
+            elif op == "!=":
+                collection = collection.filter(ee.Filter.neq(prop_name, value))
+            elif op == ">":
+                collection = collection.filter(ee.Filter.gt(prop_name, value))
+            elif op == ">=":
+                collection = collection.filter(ee.Filter.gte(prop_name, value))
+            elif op == "<":
+                collection = collection.filter(ee.Filter.lt(prop_name, value))
+            elif op == "<=":
+                collection = collection.filter(ee.Filter.lte(prop_name, value))
+        return collection
+
+    def _apply_image_collection_filters(self, collection):
+        """Apply the Load tab filters used by ImageCollection Preview Info."""
+        import ee
+
+        if self.use_date_filter and self.start_date and self.end_date:
+            self.progress.emit("Applying date filter...")
+            collection = collection.filterDate(self.start_date, self.end_date)
+
+        if self.bbox:
+            self.progress.emit("Applying spatial filter...")
+            geometry = ee.Geometry.Rectangle(self.bbox, geodesic=False)
+            collection = collection.filterBounds(geometry)
+
+        if self.cloud_cover is not None and self.cloud_property:
+            self.progress.emit("Applying cloud filter...")
+            collection = collection.filter(
+                ee.Filter.lt(self.cloud_property, self.cloud_cover)
+            )
+
+        if self.property_filters:
+            self.progress.emit("Applying property filters...")
+            collection = self._apply_property_filters(collection)
+
+        return collection
+
+    def _apply_feature_collection_filters(self, collection):
+        """Apply supported Load tab filters to FeatureCollection Preview Info."""
+        import ee
+
+        if self.bbox:
+            self.progress.emit("Applying spatial filter...")
+            geometry = ee.Geometry.Rectangle(self.bbox, geodesic=False)
+            collection = collection.filterBounds(geometry)
+
+        if self.property_filters:
+            self.progress.emit("Applying property filters...")
+            collection = self._apply_property_filters(collection)
+
+        return collection
+
+    def _filter_summary(self):
+        """Return a short text summary of the filters applied to preview info."""
+        filters = []
+        if self.use_date_filter and self.start_date and self.end_date:
+            filters.append(f"Date: {self.start_date} to {self.end_date}")
+        if self.bbox:
+            west, south, east, north = self.bbox
+            filters.append(
+                "Bounds: " f"{west:.5f}, {south:.5f}, {east:.5f}, {north:.5f}"
+            )
+        if self.cloud_cover is not None and self.cloud_property:
+            filters.append(f"Cloud: {self.cloud_property} < {self.cloud_cover}")
+        if self.property_filters:
+            filters.append(f"Property filters: {len(self.property_filters)}")
+        return "\n".join(filters)
 
     def run(self):
         try:
@@ -111,10 +196,14 @@ class PreviewInfoThread(QThread):
                 # Create an ImageCollection from the selected images
                 image_ids = [img_info["id"] for img_info in self.selected_images]
                 collection = ee.ImageCollection(image_ids)
+                collection = self._apply_image_collection_filters(collection)
 
                 size = collection.size().getInfo()
                 info_text = f"Type: ImageCollection (filtered)\n"
                 info_text += f"From: {self.asset_id}\n"
+                filter_summary = self._filter_summary()
+                if filter_summary:
+                    info_text += f"Filters:\n{filter_summary}\n\n"
                 info_text += f"Size: {size} images\n\n"
 
                 # Get date range
@@ -142,12 +231,15 @@ class PreviewInfoThread(QThread):
                 self.finished.emit(info_text)
                 return
 
-            self.progress.emit(f"Detecting asset type...")
+            self.progress.emit("Detecting asset type...")
 
-            data_type = detect_asset_type(self.asset_id)
+            data_type = self.asset_type or detect_asset_type(self.asset_id)
             info_text = f"Type: {data_type}\nID: {self.asset_id}\n\n"
+            filter_summary = self._filter_summary()
+            if filter_summary:
+                info_text += f"Filters:\n{filter_summary}\n\n"
 
-            self.progress.emit(f"Getting info...")
+            self.progress.emit("Getting info...")
 
             if data_type == "Image":
                 image = ee.Image(self.asset_id)
@@ -160,13 +252,14 @@ class PreviewInfoThread(QThread):
 
             elif data_type == "ImageCollection":
                 collection = ee.ImageCollection(self.asset_id)
-                if self.use_date_filter and self.start_date and self.end_date:
-                    collection = collection.filterDate(self.start_date, self.end_date)
+                collection = self._apply_image_collection_filters(collection)
 
+                self.progress.emit("Counting filtered images...")
                 size = collection.size().getInfo()
                 info_text += f"Size: {size} images\n"
 
                 if size > 0:
+                    self.progress.emit("Getting band information...")
                     first = collection.first()
                     bands = first.bandNames().getInfo()
                     info_text += f"\nBands per image: {len(bands)}\n"
@@ -181,6 +274,8 @@ class PreviewInfoThread(QThread):
 
             elif data_type == "FeatureCollection":
                 fc = ee.FeatureCollection(self.asset_id)
+                fc = self._apply_feature_collection_filters(fc)
+                self.progress.emit("Counting filtered features...")
                 size = fc.size().getInfo()
                 info_text += f"Size: {size} features\n"
             else:
@@ -2354,15 +2449,17 @@ class InspectorMapTool:
 class CatalogDockWidget(QDockWidget):
     """Main catalog browser panel for GEE datasets."""
 
-    def __init__(self, iface, parent=None):
+    def __init__(self, iface, plugin=None, parent=None):
         """Initialize the dock widget.
 
         Args:
             iface: QGIS interface instance.
+            plugin: Main plugin instance, used by the AI assistant tools.
             parent: Parent widget.
         """
         super().__init__("GEE Data Catalogs", parent)
         self.iface = iface
+        self.plugin = plugin
         self._selected_dataset = None
         self._catalog_thread = None
         self._image_list_thread = None
@@ -2447,36 +2544,44 @@ class CatalogDockWidget(QDockWidget):
         layout.addWidget(self.tab_widget)
 
         # Browse tab
-        browse_tab = self._create_browse_tab()
-        self.tab_widget.addTab(browse_tab, "Browse")
+        self.browse_tab = self._create_browse_tab()
+        self.tab_widget.addTab(self.browse_tab, "Browse")
 
         # Search tab
-        search_tab = self._create_search_tab()
-        self.tab_widget.addTab(search_tab, "Search")
+        self.search_tab = self._create_search_tab()
+        self.tab_widget.addTab(self.search_tab, "Search")
 
         # Time Series tab
-        timeseries_tab = self._create_timeseries_tab()
-        self.tab_widget.addTab(timeseries_tab, "Time Series")
+        self.timeseries_tab = self._create_timeseries_tab()
+        self.tab_widget.addTab(self.timeseries_tab, "Time Series")
 
         # Load tab
-        load_tab = self._create_load_tab()
-        self.tab_widget.addTab(load_tab, "Load")
+        self.load_tab = self._create_load_tab()
+        self.tab_widget.addTab(self.load_tab, "Load")
 
         # Code tab
-        code_tab = self._create_code_tab()
-        self.tab_widget.addTab(code_tab, "Code")
+        self.code_tab = self._create_code_tab()
+        self.tab_widget.addTab(self.code_tab, "Code")
 
         # Conversion tab
-        conversion_tab = self._create_conversion_tab()
-        self.tab_widget.addTab(conversion_tab, "Conversion")
+        self.conversion_tab = self._create_conversion_tab()
+        self.tab_widget.addTab(self.conversion_tab, "Conversion")
 
         # Inspector tab
-        inspector_tab = self._create_inspector_tab()
-        self.tab_widget.addTab(inspector_tab, "Inspector")
+        self.inspector_tab = self._create_inspector_tab()
+        self.tab_widget.addTab(self.inspector_tab, "Inspector")
 
         # Export tab
-        export_tab = self._create_export_tab()
-        self.tab_widget.addTab(export_tab, "Export")
+        self.export_tab = self._create_export_tab()
+        self.tab_widget.addTab(self.export_tab, "Export")
+
+        # AI assistant tab
+        from .chat_dock import ChatPanelWidget
+
+        self.ai_assistant_tab = ChatPanelWidget(
+            self.iface, plugin=self.plugin, parent=self
+        )
+        self.tab_widget.addTab(self.ai_assistant_tab, "AI Assistant")
 
         # Progress bar
         self.progress_bar = QProgressBar()
@@ -3312,6 +3417,16 @@ class CatalogDockWidget(QDockWidget):
 
         slider_layout.addLayout(slider_btn_layout)
 
+        keep_layout = QHBoxLayout()
+        self.ts_keep_current_btn = QPushButton("Keep Current Layer")
+        self.ts_keep_current_btn.setEnabled(False)
+        self.ts_keep_current_btn.setToolTip(
+            "Add the currently displayed time step as a separate layer that will not be replaced by playback."
+        )
+        self.ts_keep_current_btn.clicked.connect(self._keep_current_timeseries_layer)
+        keep_layout.addWidget(self.ts_keep_current_btn)
+        slider_layout.addLayout(keep_layout)
+
         # Animation speed control
         speed_layout = QHBoxLayout()
         speed_layout.addWidget(QLabel("Speed:"))
@@ -3566,6 +3681,9 @@ class CatalogDockWidget(QDockWidget):
 
         self.dataset_id_input = QLineEdit()
         self.dataset_id_input.setPlaceholderText("e.g., LANDSAT/LC09/C02/T1_L2")
+        self.dataset_id_input.textEdited.connect(
+            self._clear_selected_dataset_if_asset_changed
+        )
         id_layout.addRow("Asset ID:", self.dataset_id_input)
 
         self.layer_name_input = QLineEdit()
@@ -5429,12 +5547,22 @@ class CatalogDockWidget(QDockWidget):
 
     def _on_tab_changed(self, index):
         """Handle tab changes."""
-        # Refresh layer count when switching to Inspector tab (index 6 after adding Time Series tab)
-        if index == 6:  # Inspector tab
+        current_widget = self.tab_widget.widget(index)
+        if current_widget == getattr(self, "inspector_tab", None):
             self._refresh_inspector_layers()
-        elif index == 7:  # Export tab
+        elif current_widget == getattr(self, "export_tab", None):
             self._refresh_export_layers()
             self._refresh_vector_layers()
+
+        plugin = getattr(self, "plugin", None)
+        if plugin is not None and hasattr(plugin, "_sync_panel_actions"):
+            plugin._sync_panel_actions()
+
+    def show_ai_assistant_tab(self):
+        """Show the AI assistant inside the main catalog panel."""
+        self.tab_widget.setCurrentWidget(self.ai_assistant_tab)
+        self.show()
+        self.raise_()
 
     def _toggle_image_selection(self, checked):
         """Toggle visibility of image selection widgets."""
@@ -5442,6 +5570,14 @@ class CatalogDockWidget(QDockWidget):
         self.fetch_images_btn.setVisible(checked)
         self.image_limit_spin.setVisible(checked)
         self.agg_method.setEnabled(not checked)
+
+    def _clear_selected_dataset_if_asset_changed(self, asset_id):
+        """Forget catalog metadata when the user edits the asset ID manually."""
+        if (
+            self._selected_dataset
+            and self._selected_dataset.get("id") != asset_id.strip()
+        ):
+            self._selected_dataset = None
 
     def _start_catalog_load(self):
         """Start loading catalogs in background."""
@@ -5781,8 +5917,7 @@ class CatalogDockWidget(QDockWidget):
             self.dataset_id_input.setText(self._selected_dataset.get("id", ""))
             self.layer_name_input.setText(self._selected_dataset.get("name", "")[:50])
 
-            # Switch to Load tab (index 3 after Time Series tab)
-            self.tab_widget.setCurrentIndex(3)
+            self.tab_widget.setCurrentWidget(self.load_tab)
 
     def _configure_timeseries(self):
         """Configure time series from the selected dataset."""
@@ -5830,8 +5965,7 @@ class CatalogDockWidget(QDockWidget):
             # Generate and copy time series Python code snippet to clipboard
             self._copy_timeseries_code_for_dataset(asset_id, name, start_date, end_date)
 
-            # Switch to Time Series tab (index 2)
-            self.tab_widget.setCurrentIndex(2)
+            self.tab_widget.setCurrentWidget(self.timeseries_tab)
 
     def _copy_timeseries_code_for_dataset(self, asset_id, name, start_date, end_date):
         """Generate and copy time series Python code snippet to clipboard."""
@@ -5931,71 +6065,30 @@ for f in data['features']:
             vis_params = dataset.get("vis_params", {})
             name = dataset.get("name", asset_id.split("/")[-1])[:50]
 
-            # Auto-detect the asset type
             from ..core.ee_utils import detect_asset_type, add_ee_layer
 
-            catalog_type = dataset.get("type", "").lower()
-
-            # Try to load based on catalog type first, then fall back to detection
+            catalog_type = self._catalog_asset_type(dataset)
             ee_object = None
-            actual_type = None
+            actual_type = catalog_type
 
-            try:
-                if catalog_type == "image":
-                    ee_object = ee.Image(asset_id)
-                    ee_object.bandNames().getInfo()  # Verify it works
-                    actual_type = "Image"
-                elif catalog_type == "imagecollection":
-                    collection = ee.ImageCollection(asset_id)
-                    collection.size().getInfo()  # Verify it works
-                    ee_object = collection.mosaic()
-                    actual_type = "ImageCollection"
-                elif catalog_type == "bigquerytable":
-                    # BigQuery tables require loadBigQueryTable()
-                    bigquery_table = dataset.get("bigquery_table", "")
-                    if bigquery_table:
-                        ee_object = ee.FeatureCollection.loadBigQueryTable(
-                            bigquery_table
-                        )
-                        ee_object.size().getInfo()  # Verify it works
-                        actual_type = "BigQueryTable"
-                    else:
-                        raise ValueError(
-                            f"BigQuery table name not found for: {asset_id}"
-                        )
-                elif catalog_type == "featurecollection" or catalog_type == "table":
-                    ee_object = ee.FeatureCollection(asset_id)
-                    ee_object.size().getInfo()  # Verify it works
-                    actual_type = "FeatureCollection"
-            except Exception as type_err:
-                # Catalog type was wrong or API call failed, auto-detect
-                QgsMessageLog.logMessage(
-                    f"Loading as {catalog_type} failed for {asset_id}: {type_err}",
-                    "GEE Data Catalogs",
-                    Qgis.MessageLevel.Warning,
-                )
-
-            # If loading based on catalog type failed, auto-detect
-            if ee_object is None:
-                # BigQuery tables cannot be auto-detected, must have bigquery_table field
-                if catalog_type == "bigquerytable":
-                    bigquery_table = dataset.get("bigquery_table", "")
-                    raise ValueError(
-                        f"Failed to load BigQuery table. Table name: {bigquery_table or 'not found'}"
-                    )
-
+            if not actual_type:
                 self._show_progress(f"Detecting asset type for {asset_id}...")
                 QCoreApplication.processEvents()
                 actual_type = detect_asset_type(asset_id)
 
-                if actual_type == "Image":
-                    ee_object = ee.Image(asset_id)
-                elif actual_type == "ImageCollection":
-                    ee_object = ee.ImageCollection(asset_id).mosaic()
-                elif actual_type == "FeatureCollection":
-                    ee_object = ee.FeatureCollection(asset_id)
-                else:
-                    raise ValueError(f"Could not determine asset type for: {asset_id}")
+            if actual_type == "Image":
+                ee_object = ee.Image(asset_id)
+            elif actual_type == "ImageCollection":
+                ee_object = ee.ImageCollection(asset_id).mosaic()
+            elif actual_type == "FeatureCollection":
+                ee_object = ee.FeatureCollection(asset_id)
+            elif actual_type == "BigQueryTable":
+                bigquery_table = dataset.get("bigquery_table", "")
+                if not bigquery_table:
+                    raise ValueError(f"BigQuery table name not found for: {asset_id}")
+                ee_object = ee.FeatureCollection.loadBigQueryTable(bigquery_table)
+            else:
+                raise ValueError(f"Could not determine asset type for: {asset_id}")
 
             # Add layer
             add_ee_layer(ee_object, vis_params, name)
@@ -6081,11 +6174,11 @@ for f in data['features']:
         if items:
             dataset = items[0].data(0, Qt.ItemDataRole.UserRole)
             if dataset:
+                self._selected_dataset = dataset
                 # Populate the load tab with dataset info
                 self.dataset_id_input.setText(dataset.get("id", ""))
                 self.layer_name_input.setText(dataset.get("name", "")[:50])
-                # Switch to Load tab (index 3 after Time Series tab)
-                self.tab_widget.setCurrentIndex(3)
+                self.tab_widget.setCurrentWidget(self.load_tab)
 
     def _configure_search_timeseries(self):
         """Configure time series from selected search result."""
@@ -6226,10 +6319,14 @@ for f in data['features']:
                 # Load as composite - auto-detect asset type
                 from ..core.ee_utils import detect_asset_type, add_ee_layer
 
-                self._show_progress(f"Detecting asset type for {asset_id}...")
-                QCoreApplication.processEvents()
-
-                asset_type = detect_asset_type(asset_id)
+                asset_type = self._selected_asset_type(asset_id)
+                if asset_type:
+                    self._show_progress(f"Loading {asset_type} {asset_id}...")
+                    QCoreApplication.processEvents()
+                else:
+                    self._show_progress(f"Detecting asset type for {asset_id}...")
+                    QCoreApplication.processEvents()
+                    asset_type = detect_asset_type(asset_id)
 
                 if asset_type == "ImageCollection":
                     ee_object = self._load_image_collection(asset_id)
@@ -6237,6 +6334,13 @@ for f in data['features']:
                     ee_object = ee.Image(asset_id)
                 elif asset_type == "FeatureCollection":
                     ee_object = ee.FeatureCollection(asset_id)
+                elif asset_type == "BigQueryTable":
+                    bigquery_table = self._selected_dataset.get("bigquery_table", "")
+                    if not bigquery_table:
+                        raise ValueError(
+                            f"BigQuery table name not found for: {asset_id}"
+                        )
+                    ee_object = ee.FeatureCollection.loadBigQueryTable(bigquery_table)
                 else:
                     # Try each type until one works
                     for loader_fn in [
@@ -6253,9 +6357,10 @@ for f in data['features']:
                         raise ValueError(f"Could not load asset: {asset_id}")
 
                 # Build vis_params based on asset type
-                is_feature_collection = asset_type == "FeatureCollection" or isinstance(
-                    ee_object, ee.FeatureCollection
-                )
+                is_feature_collection = asset_type in {
+                    "FeatureCollection",
+                    "BigQueryTable",
+                } or isinstance(ee_object, ee.FeatureCollection)
                 vis_params = self._build_vis_params(
                     for_feature_collection=is_feature_collection
                 )
@@ -6326,6 +6431,30 @@ for f in data['features']:
         self.vis_min_input.clear()
         self.vis_max_input.clear()
         self.palette_input.clear()
+
+    @staticmethod
+    def _catalog_asset_type(dataset):
+        """Return a normalized asset type from catalog metadata."""
+        if not dataset:
+            return None
+
+        catalog_type = str(dataset.get("type", "")).lower().replace("_", "")
+        catalog_type = catalog_type.replace(" ", "")
+        if catalog_type == "image":
+            return "Image"
+        if catalog_type == "imagecollection":
+            return "ImageCollection"
+        if catalog_type in {"featurecollection", "table"}:
+            return "FeatureCollection"
+        if catalog_type == "bigquerytable":
+            return "BigQueryTable"
+        return None
+
+    def _selected_asset_type(self, asset_id):
+        """Return the selected catalog asset type when it matches the load ID."""
+        if self._selected_dataset and self._selected_dataset.get("id") == asset_id:
+            return self._catalog_asset_type(self._selected_dataset)
+        return None
 
     def _build_vis_params(self, for_feature_collection: bool = False):
         """Build visualization parameters from UI inputs.
@@ -6472,10 +6601,31 @@ for f in data['features']:
         end_date = (
             self.end_date.date().toString("yyyy-MM-dd") if use_date_filter else None
         )
+        bbox = self._get_spatial_filter_load()
+        cloud_cover = (
+            self.cloud_cover_spin.value() if self.use_cloud_filter.isChecked() else None
+        )
+        cloud_property = None
+        if cloud_cover is not None:
+            custom_cloud_prop = self.cloud_property_input.text().strip()
+            cloud_property = self._get_cloud_property(asset_id, custom_cloud_prop)
+        property_filters = self._parse_property_filters(
+            self.load_property_filters.toPlainText()
+        )
+        asset_type = self._selected_asset_type(asset_id)
 
         # Start background thread
         self._preview_thread = PreviewInfoThread(
-            asset_id, use_date_filter, start_date, end_date, selected_images
+            asset_id=asset_id,
+            asset_type=asset_type,
+            use_date_filter=use_date_filter,
+            start_date=start_date,
+            end_date=end_date,
+            bbox=bbox,
+            cloud_cover=cloud_cover,
+            cloud_property=cloud_property,
+            property_filters=property_filters,
+            selected_images=selected_images,
         )
         self._preview_thread.finished.connect(self._on_preview_finished)
         self._preview_thread.error.connect(self._on_preview_error)
@@ -6733,9 +6883,7 @@ for f in data['features']:
 
         # Paste code to Code tab and switch to it
         self.code_input.setPlainText(code)
-        self.tab_widget.setCurrentIndex(
-            4
-        )  # Switch to Code tab (index 4 after Time Series tab)
+        self.tab_widget.setCurrentWidget(self.code_tab)
 
     def _run_code(self):
         """Execute the code in the console."""
@@ -7182,7 +7330,9 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         self.progress_bar.setVisible(True)
         self.progress_bar.setRange(0, 0)
         self.status_label.setText(message)
-        self.status_label.setStyleSheet("color: blue; font-size: 10px;")
+        self.status_label.setStyleSheet(
+            "color: #64b5f6; font-size: 10px; font-weight: bold;"
+        )
 
     def _show_success(self, message):
         """Show success message."""
@@ -7760,6 +7910,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
         self.ts_create_btn.setEnabled(False)
         self.ts_export_btn.setEnabled(False)
+        self.ts_keep_current_btn.setEnabled(False)
 
         try:
             start_date = self.ts_start_date.date().toString("yyyy-MM-dd")
@@ -7824,6 +7975,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         except Exception as e:
             QApplication.restoreOverrideCursor()
             self.ts_create_btn.setEnabled(True)
+            self.ts_keep_current_btn.setEnabled(False)
             self._show_error(f"Failed to create time series: {str(e)}")
 
     def _on_timeseries_created(self, images_data, labels):
@@ -7906,6 +8058,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
             self.ts_prev_btn.setEnabled(True)
             self.ts_play_btn.setEnabled(True)
             self.ts_next_btn.setEnabled(True)
+            self.ts_keep_current_btn.setEnabled(True)
 
             # Update label
             self.ts_current_label.setText(labels[0] if labels else "No data")
@@ -7935,6 +8088,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         """Handle time series creation error."""
         QApplication.restoreOverrideCursor()
         self.ts_create_btn.setEnabled(True)
+        self.ts_keep_current_btn.setEnabled(False)
         self._show_error(f"Time series error: {error}")
 
     # ==================== Time Series Export Methods ====================
@@ -8328,7 +8482,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
             from ..core.ee_utils import add_ee_layer
 
             image = self._timeseries_collection[index]
-            layer_name = self.ts_layer_name_input.text().strip() or "Time Series"
+            layer_name = self._timeseries_layer_base_name()
 
             # Add the layer (will replace existing layer with same name)
             add_ee_layer(image, self._timeseries_vis_params, layer_name)
@@ -8341,6 +8495,47 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
 
         except Exception as e:
             self.ts_info_label.setText(f"Error displaying image: {str(e)}")
+
+    def _timeseries_layer_base_name(self):
+        """Return the animated time series layer name."""
+        return self.ts_layer_name_input.text().strip() or "Time Series"
+
+    def _timeseries_label_for_index(self, index):
+        """Return the display label for a time series index."""
+        if 0 <= index < len(self._timeseries_labels):
+            return self._timeseries_labels[index]
+        return f"Step {index + 1}"
+
+    def _unique_qgis_layer_name(self, base_name):
+        """Return a QGIS layer name that does not already exist."""
+        name = base_name
+        suffix = 2
+        while QgsProject.instance().mapLayersByName(name):
+            name = f"{base_name} ({suffix})"
+            suffix += 1
+        return name
+
+    def _keep_current_timeseries_layer(self):
+        """Add the current time step as a persistent layer."""
+        if not self._timeseries_collection:
+            return
+
+        index = self.ts_time_slider.value()
+        if index < 0 or index >= len(self._timeseries_collection):
+            return
+
+        try:
+            from ..core.ee_utils import add_ee_layer
+
+            image = self._timeseries_collection[index]
+            label = self._timeseries_label_for_index(index)
+            base_name = self._timeseries_layer_base_name()
+            layer_name = self._unique_qgis_layer_name(f"{base_name} - {label}")
+
+            add_ee_layer(image, self._timeseries_vis_params, layer_name)
+            self.ts_info_label.setText(f"Kept current time step as layer: {layer_name}")
+        except Exception as e:
+            self.ts_info_label.setText(f"Error keeping current layer: {str(e)}")
 
     def _on_timeslider_changed(self, value):
         """Handle time slider value changed."""
@@ -8709,7 +8904,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
 
         # Paste code to Code tab and switch to it
         self.code_input.setPlainText(code)
-        self.tab_widget.setCurrentIndex(4)  # Code tab
+        self.tab_widget.setCurrentWidget(self.code_tab)
 
     def closeEvent(self, event):
         """Handle dock widget close event."""

--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -68,11 +68,14 @@ def _apply_environment_from_settings(settings):
     }
     for key, env_names in env_map.items():
         value = _setting(settings, key, "").strip()
+        if isinstance(env_names, str):
+            env_names = (env_names,)
         if value:
-            if isinstance(env_names, str):
-                env_names = (env_names,)
             for env_name in env_names:
                 os.environ[env_name] = value
+        else:
+            for env_name in env_names:
+                os.environ.pop(env_name, None)
 
 
 def _qt_value(enum_name, member_name):
@@ -234,10 +237,6 @@ class ChatWorker(QThread):
     def run(self):
         """Create a GeoAgent GEE Data Catalogs agent and execute one chat turn."""
         try:
-            from ..core.venv_manager import ensure_venv_packages_available
-
-            ensure_venv_packages_available()
-
             from geoagent import GeoAgentConfig
 
             try:
@@ -421,7 +420,9 @@ class ChatPanelWidget(QWidget):
         """Load persisted model settings into the dock controls."""
         provider = _setting(self.settings, "provider", "openai")
         index = self.provider_combo.findText(provider)
-        self.provider_combo.setCurrentIndex(index if index >= 0 else 1)
+        if index < 0:
+            index = self.provider_combo.findText("openai")
+        self.provider_combo.setCurrentIndex(index if index >= 0 else 0)
 
         model = _setting(self.settings, "model", "")
         if not model:
@@ -459,6 +460,18 @@ class ChatPanelWidget(QWidget):
         self._save_model_settings()
         self._record_prompt(prompt)
         _apply_environment_from_settings(self.settings)
+
+        try:
+            from ..core.venv_manager import ensure_venv_packages_available
+
+            ensure_venv_packages_available()
+        except Exception as exc:
+            QMessageBox.critical(
+                self,
+                "GEE Data Catalogs",
+                f"Failed to prepare AI assistant dependencies:\n{exc}",
+            )
+            return
 
         provider = self.provider_combo.currentText()
         model_id = self.model_input.text().strip()
@@ -664,14 +677,33 @@ class ChatPanelWidget(QWidget):
         except Exception:  # nosec B110
             pass
 
+    def _shutdown_worker(self):
+        """Disconnect and wait for any in-flight chat worker."""
+        worker = self._worker
+        if worker is None:
+            return
+        try:
+            worker.finished.disconnect(self._on_worker_finished)
+        except (TypeError, RuntimeError):  # nosec B110
+            pass
+        if worker.isRunning():
+            worker.quit()
+            worker.wait(5000)
+        self._worker = None
+
+    def shutdown(self):
+        """Release timers and worker resources before deletion."""
+        self._shutdown_running_state()
+        self._shutdown_worker()
+
     def hideEvent(self, event):
         """Stop the animated status timer when the dock is hidden."""
         self._shutdown_running_state()
         super().hideEvent(event)
 
     def closeEvent(self, event):
-        """Stop the animated status timer when the panel is closed."""
-        self._shutdown_running_state()
+        """Stop timers and the worker when the panel is closed."""
+        self.shutdown()
         super().closeEvent(event)
 
 
@@ -686,3 +718,13 @@ class ChatDockWidget(QDockWidget):
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
         )
         self.setMinimumWidth(300)
+
+    def shutdown(self):
+        """Forward shutdown to the embedded panel."""
+        if self.panel is not None:
+            self.panel.shutdown()
+
+    def closeEvent(self, event):
+        """Stop the embedded panel's worker before the dock closes."""
+        self.shutdown()
+        super().closeEvent(event)

--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -36,6 +36,8 @@ DEFAULT_MODELS = {
     "litellm": "openai/gpt-5.5",
 }
 PROVIDERS = ["bedrock", "openai", "anthropic", "gemini", "ollama", "litellm"]
+MAX_CONTEXT_MESSAGES = 12
+MAX_CONTEXT_CHARS = 12000
 SAMPLE_PROMPTS = [
     "Search the Earth Engine catalog for recent Sentinel-2 surface reflectance datasets.",
     "Find GEE datasets for flood mapping and tell me which one to load.",
@@ -225,6 +227,10 @@ class ChatWorker(QThread):
         self.fast = fast
         self.max_tokens = max_tokens
 
+    def _confirm_tool(self, request):
+        """Allow confirmation-required tools to run without a modal prompt."""
+        return True
+
     def run(self):
         """Create a GeoAgent GEE Data Catalogs agent and execute one chat turn."""
         try:
@@ -256,6 +262,7 @@ class ChatWorker(QThread):
                     plugin=self.plugin,
                     config=config,
                     fast=self.fast,
+                    confirm=self._confirm_tool,
                 )
             except ImportError:
                 from geoagent import for_qgis
@@ -265,7 +272,7 @@ class ChatWorker(QThread):
                     from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
 
                     extra_tools = gee_data_catalogs_tools(
-                        self.iface, project=project, plugin=self.plugin
+                        self.iface, plugin=self.plugin
                     )
                 except Exception:
                     extra_tools = []
@@ -275,6 +282,7 @@ class ChatWorker(QThread):
                     config=config,
                     fast=self.fast,
                     extra_tools=extra_tools,
+                    confirm=self._confirm_tool,
                 )
 
             response = agent.chat(self.prompt)
@@ -301,11 +309,11 @@ class ChatWorker(QThread):
             )
 
 
-class ChatDockWidget(QDockWidget):
-    """Dock widget that sends user prompts to a GeoAgent catalog agent."""
+class ChatPanelWidget(QWidget):
+    """Widget that sends user prompts to a GeoAgent catalog agent."""
 
     def __init__(self, iface, plugin=None, parent=None):
-        super().__init__("GEE Data Catalogs AI Assistant", parent)
+        super().__init__(parent)
         self.iface = iface
         self.plugin = plugin
         self.settings = QSettings()
@@ -321,19 +329,14 @@ class ChatDockWidget(QDockWidget):
         self._status_timer.setInterval(500)
         self._status_timer.timeout.connect(self._update_running_status)
 
-        self.setAllowedAreas(
-            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
-        )
         self.setMinimumWidth(300)
 
         self._setup_ui()
         self._load_settings()
 
     def _setup_ui(self):
-        """Build the chat dock widgets and signal connections."""
-        main_widget = QWidget()
-        self.setWidget(main_widget)
-        layout = QVBoxLayout(main_widget)
+        """Build the chat widgets and signal connections."""
+        layout = QVBoxLayout(self)
         layout.setSpacing(8)
 
         model_group = QGroupBox("Model")
@@ -461,6 +464,7 @@ class ChatDockWidget(QDockWidget):
         model_id = self.model_input.text().strip()
         fast = self.fast_check.isChecked()
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
+        prompt_with_context = self._build_prompt_with_context(prompt)
 
         self._append_message("You", prompt, markdown=False)
         self.prompt_input.clear()
@@ -471,7 +475,7 @@ class ChatDockWidget(QDockWidget):
         self._worker = ChatWorker(
             self.iface,
             self.plugin,
-            prompt,
+            prompt_with_context,
             provider,
             model_id,
             fast,
@@ -480,6 +484,34 @@ class ChatDockWidget(QDockWidget):
         )
         self._worker.finished.connect(self._on_worker_finished)
         self._worker.start()
+
+    def _build_prompt_with_context(self, prompt):
+        """Include recent chat transcript so follow-up turns have context."""
+        if not self._messages:
+            return prompt
+
+        history_lines = []
+        for msg in self._messages[-MAX_CONTEXT_MESSAGES:]:
+            body = msg.get("body", "").strip()
+            if not body:
+                continue
+            role = "User" if msg.get("sender") == "You" else "Assistant"
+            history_lines.append(f"{role}: {body}")
+
+        if not history_lines:
+            return prompt
+
+        history = "\n\n".join(history_lines)
+        if len(history) > MAX_CONTEXT_CHARS:
+            history = history[-MAX_CONTEXT_CHARS:]
+            history = f"[Earlier history truncated]\n{history}"
+
+        return (
+            "Use the recent conversation history for context. The current user "
+            "request is the authoritative request to answer now.\n\n"
+            f"Recent conversation:\n{history}\n\n"
+            f"Current user request:\n{prompt}"
+        )
 
     def _select_sample_prompt(self, prompt):
         """Copy the selected sample prompt into the editor."""
@@ -638,6 +670,19 @@ class ChatDockWidget(QDockWidget):
         super().hideEvent(event)
 
     def closeEvent(self, event):
-        """Stop the animated status timer when the dock is closed."""
+        """Stop the animated status timer when the panel is closed."""
         self._shutdown_running_state()
         super().closeEvent(event)
+
+
+class ChatDockWidget(QDockWidget):
+    """Dock wrapper for the GeoAgent chat panel."""
+
+    def __init__(self, iface, plugin=None, parent=None):
+        super().__init__("GEE Data Catalogs AI Assistant", parent)
+        self.panel = ChatPanelWidget(iface, plugin=plugin, parent=self)
+        self.setWidget(self.panel)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
+        self.setMinimumWidth(300)

--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -1,0 +1,643 @@
+"""Dockable AI assistant for the GEE Data Catalogs plugin."""
+
+import html
+import os
+import re
+import time
+import traceback
+
+from qgis.PyQt.QtCore import QSettings, QThread, QTimer, Qt, pyqtSignal
+from qgis.PyQt.QtGui import QGuiApplication, QTextCursor
+from qgis.PyQt.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDockWidget,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QPlainTextEdit,
+    QSizePolicy,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+SETTINGS_PREFIX = "GeeDataCatalogs/"
+DEFAULT_MODELS = {
+    "bedrock": "us.anthropic.claude-sonnet-4-6",
+    "openai": "gpt-5.5",
+    "anthropic": "claude-sonnet-4-6",
+    "gemini": "gemini-3.1-pro-preview",
+    "ollama": "qwen3.5:4b",
+    "litellm": "openai/gpt-5.5",
+}
+PROVIDERS = ["bedrock", "openai", "anthropic", "gemini", "ollama", "litellm"]
+SAMPLE_PROMPTS = [
+    "Search the Earth Engine catalog for recent Sentinel-2 surface reflectance datasets.",
+    "Find GEE datasets for flood mapping and tell me which one to load.",
+    "Search for population datasets and summarize the best options.",
+    "Configure the Load tab for LANDSAT/LC09/C02/T1_L2 with RGB bands.",
+    "Load a median Sentinel-2 composite for the current map extent.",
+    "List current QGIS layers and identify which Earth Engine layers are loaded.",
+    "Initialize Earth Engine using my saved project setting.",
+    "Open the catalog Search tab.",
+]
+
+
+def _setting(settings, key, default="", value_type=str):
+    """Read a plugin setting value."""
+    return settings.value(f"{SETTINGS_PREFIX}{key}", default, type=value_type)
+
+
+def _apply_environment_from_settings(settings):
+    """Apply provider credentials from QSettings to the current QGIS process."""
+    env_map = {
+        "openai_api_key": "OPENAI_API_KEY",
+        "anthropic_api_key": "ANTHROPIC_API_KEY",
+        "gemini_api_key": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        "aws_region": "AWS_REGION",
+        "ollama_host": "OLLAMA_HOST",
+        "litellm_api_key": "LITELLM_API_KEY",
+        "litellm_base_url": "LITELLM_BASE_URL",
+    }
+    for key, env_names in env_map.items():
+        value = _setting(settings, key, "").strip()
+        if value:
+            if isinstance(env_names, str):
+                env_names = (env_names,)
+            for env_name in env_names:
+                os.environ[env_name] = value
+
+
+def _qt_value(enum_name, member_name):
+    """Return a Qt enum member across PyQt enum API variants."""
+    container = getattr(Qt, enum_name, Qt)
+    return getattr(container, member_name)
+
+
+def _enum_value(cls, enum_name, member_name):
+    """Return an enum member from either scoped or legacy Qt APIs."""
+    container = getattr(cls, enum_name, cls)
+    return getattr(container, member_name)
+
+
+def _plain_text_to_html(text):
+    """Convert plain text to basic HTML."""
+    return html.escape(text).replace("\n", "<br>")
+
+
+def _inline_markdown_to_html(text):
+    """Convert inline Markdown spans to HTML."""
+    text = html.escape(text)
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
+    text = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", text)
+    return text
+
+
+def _markdown_to_basic_html(markdown):
+    """Small fallback renderer for common Markdown."""
+    lines = markdown.splitlines()
+    html_lines = []
+    in_ul = False
+    in_ol = False
+    in_code = False
+    code_lines = []
+
+    def close_lists():
+        nonlocal in_ul, in_ol
+        if in_ul:
+            html_lines.append("</ul>")
+            in_ul = False
+        if in_ol:
+            html_lines.append("</ol>")
+            in_ol = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            if in_code:
+                html_lines.append(
+                    f"<pre><code>{html.escape(chr(10).join(code_lines))}</code></pre>"
+                )
+                code_lines = []
+                in_code = False
+            else:
+                close_lists()
+                in_code = True
+            continue
+        if in_code:
+            code_lines.append(line)
+            continue
+        if not stripped:
+            close_lists()
+            html_lines.append("")
+            continue
+        heading = re.match(r"^(#{1,3})\s+(.+)$", stripped)
+        if heading:
+            close_lists()
+            level = len(heading.group(1))
+            html_lines.append(
+                f"<h{level}>{_inline_markdown_to_html(heading.group(2))}</h{level}>"
+            )
+            continue
+        bullet = re.match(r"^[-*]\s+(.+)$", stripped)
+        if bullet:
+            if in_ol:
+                html_lines.append("</ol>")
+                in_ol = False
+            if not in_ul:
+                html_lines.append("<ul>")
+                in_ul = True
+            html_lines.append(f"<li>{_inline_markdown_to_html(bullet.group(1))}</li>")
+            continue
+        numbered = re.match(r"^\d+\.\s+(.+)$", stripped)
+        if numbered:
+            if in_ul:
+                html_lines.append("</ul>")
+                in_ul = False
+            if not in_ol:
+                html_lines.append("<ol>")
+                in_ol = True
+            html_lines.append(f"<li>{_inline_markdown_to_html(numbered.group(1))}</li>")
+            continue
+        close_lists()
+        html_lines.append(f"<p>{_inline_markdown_to_html(stripped)}</p>")
+
+    if in_code:
+        html_lines.append(
+            f"<pre><code>{html.escape(chr(10).join(code_lines))}</code></pre>"
+        )
+    close_lists()
+    return "\n".join(html_lines)
+
+
+class PromptTextEdit(QPlainTextEdit):
+    """Prompt editor with chat-friendly keyboard shortcuts."""
+
+    send_requested = pyqtSignal()
+    previous_requested = pyqtSignal()
+    next_requested = pyqtSignal()
+
+    def keyPressEvent(self, event):
+        """Handle send and prompt-history keyboard shortcuts."""
+        key = event.key()
+        modifiers = event.modifiers()
+        control = _qt_value("KeyboardModifier", "ControlModifier")
+        key_return = _qt_value("Key", "Key_Return")
+        key_enter = _qt_value("Key", "Key_Enter")
+        key_up = _qt_value("Key", "Key_Up")
+        key_down = _qt_value("Key", "Key_Down")
+
+        if modifiers & control and key in (key_return, key_enter):
+            self.send_requested.emit()
+            event.accept()
+            return
+        if key == key_up and not modifiers:
+            self.previous_requested.emit()
+            event.accept()
+            return
+        if key == key_down and not modifiers:
+            self.next_requested.emit()
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+
+class ChatWorker(QThread):
+    """Run GeoAgent chat without blocking the QGIS UI."""
+
+    finished = pyqtSignal(dict)
+
+    def __init__(
+        self, iface, plugin, prompt, provider, model_id, fast, max_tokens, parent=None
+    ):
+        super().__init__(parent)
+        self.iface = iface
+        self.plugin = plugin
+        self.prompt = prompt
+        self.provider = provider
+        self.model_id = model_id or None
+        self.fast = fast
+        self.max_tokens = max_tokens
+
+    def run(self):
+        """Create a GeoAgent GEE Data Catalogs agent and execute one chat turn."""
+        try:
+            from ..core.venv_manager import ensure_venv_packages_available
+
+            ensure_venv_packages_available()
+
+            from geoagent import GeoAgentConfig
+
+            try:
+                from qgis.core import QgsProject
+
+                project = QgsProject.instance()
+            except Exception:
+                project = None
+
+            config = GeoAgentConfig(
+                provider=self.provider,
+                model=self.model_id,
+                max_tokens=self.max_tokens,
+            )
+
+            try:
+                from geoagent import for_gee_data_catalogs
+
+                agent = for_gee_data_catalogs(
+                    self.iface,
+                    project=project,
+                    plugin=self.plugin,
+                    config=config,
+                    fast=self.fast,
+                )
+            except ImportError:
+                from geoagent import for_qgis
+
+                extra_tools = []
+                try:
+                    from geoagent.tools.gee_data_catalogs import gee_data_catalogs_tools
+
+                    extra_tools = gee_data_catalogs_tools(
+                        self.iface, project=project, plugin=self.plugin
+                    )
+                except Exception:
+                    extra_tools = []
+                agent = for_qgis(
+                    self.iface,
+                    project=project,
+                    config=config,
+                    fast=self.fast,
+                    extra_tools=extra_tools,
+                )
+
+            response = agent.chat(self.prompt)
+            self.finished.emit(
+                {
+                    "success": bool(response.success),
+                    "answer": response.answer_text or "",
+                    "error": response.error_message or "",
+                    "tools": ", ".join(response.executed_tools or []),
+                    "cancelled": ", ".join(response.cancelled_tools or []),
+                    "elapsed": f"{response.execution_time:.2f}s",
+                }
+            )
+        except Exception as exc:
+            self.finished.emit(
+                {
+                    "success": False,
+                    "answer": "",
+                    "error": f"{exc}\n\n{traceback.format_exc()}",
+                    "tools": "",
+                    "cancelled": "",
+                    "elapsed": "",
+                }
+            )
+
+
+class ChatDockWidget(QDockWidget):
+    """Dock widget that sends user prompts to a GeoAgent catalog agent."""
+
+    def __init__(self, iface, plugin=None, parent=None):
+        super().__init__("GEE Data Catalogs AI Assistant", parent)
+        self.iface = iface
+        self.plugin = plugin
+        self.settings = QSettings()
+        self._worker = None
+        self._prompt_history = []
+        self._history_index = None
+        self._messages = []
+        self._last_assistant_markdown = ""
+        self._status_started_at = None
+        self._status_base_text = "Running"
+        self._status_frame = 0
+        self._status_timer = QTimer(self)
+        self._status_timer.setInterval(500)
+        self._status_timer.timeout.connect(self._update_running_status)
+
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
+        self.setMinimumWidth(300)
+
+        self._setup_ui()
+        self._load_settings()
+
+    def _setup_ui(self):
+        """Build the chat dock widgets and signal connections."""
+        main_widget = QWidget()
+        self.setWidget(main_widget)
+        layout = QVBoxLayout(main_widget)
+        layout.setSpacing(8)
+
+        model_group = QGroupBox("Model")
+        model_layout = QFormLayout(model_group)
+
+        self.provider_combo = QComboBox()
+        self.provider_combo.addItems(PROVIDERS)
+        self.provider_combo.setMinimumContentsLength(10)
+        self.provider_combo.setSizeAdjustPolicy(
+            _enum_value(
+                QComboBox,
+                "SizeAdjustPolicy",
+                "AdjustToMinimumContentsLengthWithIcon",
+            )
+        )
+        self.provider_combo.currentTextChanged.connect(self._on_provider_changed)
+        model_layout.addRow("Provider:", self.provider_combo)
+
+        self.model_input = QLineEdit()
+        self.model_input.setPlaceholderText("Use provider default")
+        model_layout.addRow("Model:", self.model_input)
+
+        self.fast_check = QCheckBox("Fast mode")
+        model_layout.addRow("", self.fast_check)
+        layout.addWidget(model_group)
+
+        self.sample_combo = QComboBox()
+        self.sample_combo.addItem("Sample prompts...")
+        self.sample_combo.addItems(SAMPLE_PROMPTS)
+        self.sample_combo.setMinimumContentsLength(24)
+        self.sample_combo.setSizeAdjustPolicy(
+            _enum_value(
+                QComboBox,
+                "SizeAdjustPolicy",
+                "AdjustToMinimumContentsLengthWithIcon",
+            )
+        )
+        self.sample_combo.setSizePolicy(
+            _enum_value(QSizePolicy, "Policy", "Ignored"),
+            _enum_value(QSizePolicy, "Policy", "Fixed"),
+        )
+        self.sample_combo.currentTextChanged.connect(self._select_sample_prompt)
+        layout.addWidget(self.sample_combo)
+
+        self.transcript = QTextEdit()
+        self.transcript.setReadOnly(True)
+        self.transcript.setAcceptRichText(True)
+        self.transcript.setPlaceholderText("Conversation will appear here.")
+        layout.addWidget(self.transcript, 1)
+
+        self.prompt_input = PromptTextEdit()
+        self.prompt_input.setPlaceholderText(
+            "Ask about Earth Engine datasets, catalog search, or QGIS map actions."
+        )
+        self.prompt_input.setMaximumHeight(90)
+        self.prompt_input.send_requested.connect(self._send_prompt)
+        self.prompt_input.previous_requested.connect(self._previous_prompt)
+        self.prompt_input.next_requested.connect(self._next_prompt)
+        layout.addWidget(self.prompt_input)
+
+        button_layout = QHBoxLayout()
+        self.send_btn = QPushButton("Send")
+        self.send_btn.clicked.connect(self._send_prompt)
+        button_layout.addWidget(self.send_btn)
+
+        self.clear_btn = QPushButton("Clear")
+        self.clear_btn.clicked.connect(self._clear_transcript)
+        button_layout.addWidget(self.clear_btn)
+
+        self.copy_md_btn = QPushButton("Copy Markdown")
+        self.copy_md_btn.setEnabled(False)
+        self.copy_md_btn.clicked.connect(self._copy_latest_markdown)
+        button_layout.addWidget(self.copy_md_btn)
+        layout.addLayout(button_layout)
+
+        self.status_label = QLabel("Ready. Ctrl+Enter sends. Up/Down cycles prompts.")
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet("color: gray; font-size: 10px;")
+        layout.addWidget(self.status_label)
+
+    def _load_settings(self):
+        """Load persisted model settings into the dock controls."""
+        provider = _setting(self.settings, "provider", "openai")
+        index = self.provider_combo.findText(provider)
+        self.provider_combo.setCurrentIndex(index if index >= 0 else 1)
+
+        model = _setting(self.settings, "model", "")
+        if not model:
+            model = DEFAULT_MODELS.get(self.provider_combo.currentText(), "")
+        self.model_input.setText(model)
+        self.fast_check.setChecked(_setting(self.settings, "fast_mode", False, bool))
+
+    def _save_model_settings(self):
+        """Persist the selected provider, model, and fast-mode setting."""
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}provider", self.provider_combo.currentText()
+        )
+        self.settings.setValue(f"{SETTINGS_PREFIX}model", self.model_input.text())
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}fast_mode", self.fast_check.isChecked()
+        )
+
+    def _on_provider_changed(self, provider):
+        """Update the model field when the provider changes."""
+        self.model_input.setText(DEFAULT_MODELS.get(provider, ""))
+
+    def _send_prompt(self):
+        """Start a chat request for the current prompt."""
+        prompt = self.prompt_input.toPlainText().strip()
+        if not prompt:
+            return
+        if self._worker is not None:
+            QMessageBox.information(
+                self,
+                "GEE Data Catalogs",
+                "A request is already running. Wait for it to finish first.",
+            )
+            return
+
+        self._save_model_settings()
+        self._record_prompt(prompt)
+        _apply_environment_from_settings(self.settings)
+
+        provider = self.provider_combo.currentText()
+        model_id = self.model_input.text().strip()
+        fast = self.fast_check.isChecked()
+        max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
+
+        self._append_message("You", prompt, markdown=False)
+        self.prompt_input.clear()
+        self.status_label.setStyleSheet("color: #1976D2; font-size: 10px;")
+        self._start_running_status("Running GeoAgent")
+        self.send_btn.setEnabled(False)
+
+        self._worker = ChatWorker(
+            self.iface,
+            self.plugin,
+            prompt,
+            provider,
+            model_id,
+            fast,
+            max_tokens,
+            self,
+        )
+        self._worker.finished.connect(self._on_worker_finished)
+        self._worker.start()
+
+    def _select_sample_prompt(self, prompt):
+        """Copy the selected sample prompt into the editor."""
+        if prompt and prompt != "Sample prompts...":
+            self.prompt_input.setPlainText(prompt)
+            self.prompt_input.setFocus()
+
+    def _record_prompt(self, prompt):
+        """Store a submitted prompt in history."""
+        if not self._prompt_history or self._prompt_history[-1] != prompt:
+            self._prompt_history.append(prompt)
+        self._history_index = None
+
+    def _previous_prompt(self):
+        """Load the previous prompt from history."""
+        if not self._prompt_history:
+            return
+        if self._history_index is None:
+            self._history_index = len(self._prompt_history) - 1
+        else:
+            self._history_index = (self._history_index - 1) % len(self._prompt_history)
+        self._set_prompt_from_history()
+
+    def _next_prompt(self):
+        """Load the next prompt from history."""
+        if not self._prompt_history:
+            return
+        if self._history_index is None:
+            self._history_index = 0
+        else:
+            self._history_index = (self._history_index + 1) % len(self._prompt_history)
+        self._set_prompt_from_history()
+
+    def _set_prompt_from_history(self):
+        """Set prompt from history."""
+        self.prompt_input.setPlainText(self._prompt_history[self._history_index])
+        self.prompt_input.setFocus()
+
+    def _on_worker_finished(self, result):
+        """Render the completed chat worker result."""
+        self._stop_running_status()
+        if result.get("success"):
+            answer = result.get("answer") or "(No text response.)"
+            details = []
+            if result.get("tools"):
+                details.append(f"Tools: {result['tools']}")
+            if result.get("elapsed"):
+                details.append(f"Elapsed: {result['elapsed']}")
+            if details:
+                answer = f"{answer}\n\n" + "\n".join(details)
+            self._append_message("GeoAgent", answer, markdown=True)
+            self.status_label.setText("Ready")
+            self.status_label.setStyleSheet("color: gray; font-size: 10px;")
+        else:
+            error = result.get("error") or "Unknown error"
+            cancelled = result.get("cancelled")
+            if cancelled:
+                error = f"{error}\nCancelled tools: {cancelled}"
+            self._append_message("GeoAgent", f"Error:\n{error}", markdown=False)
+            self.status_label.setText("Error")
+            self.status_label.setStyleSheet("color: red; font-size: 10px;")
+
+        self.send_btn.setEnabled(True)
+        self._worker = None
+
+    def _start_running_status(self, base_text):
+        """Start or update the animated status text."""
+        self._status_base_text = base_text
+        if self._status_started_at is None:
+            self._status_started_at = time.monotonic()
+            self._status_frame = 0
+        if not self._status_timer.isActive():
+            self._status_timer.start()
+        self._update_running_status()
+
+    def _stop_running_status(self):
+        """Stop the animated status text."""
+        if self._status_timer.isActive():
+            self._status_timer.stop()
+        self._status_started_at = None
+        self._status_frame = 0
+
+    def _update_running_status(self):
+        """Refresh the animated status text."""
+        if self._status_started_at is None:
+            return
+        elapsed = int(time.monotonic() - self._status_started_at)
+        spinner = ("-", "\\", "|", "/")[self._status_frame % 4]
+        self._status_frame += 1
+        dots = "." * (self._status_frame % 4)
+        if elapsed >= 30:
+            suffix = "large QGIS operations can take a while"
+        elif elapsed >= 10:
+            suffix = "running tools and waiting for the model"
+        else:
+            suffix = "working"
+        self.status_label.setText(
+            f"{spinner} {self._status_base_text}{dots} {elapsed}s - {suffix}"
+        )
+
+    def _append_message(self, sender, message, markdown=False):
+        """Append a chat message and refresh the transcript."""
+        body = message.strip()
+        self._messages.append({"sender": sender, "body": body, "markdown": markdown})
+        if markdown:
+            self._last_assistant_markdown = body
+            self.copy_md_btn.setEnabled(True)
+        self._render_transcript()
+
+    def _render_transcript(self):
+        """Render the stored chat messages as HTML."""
+        blocks = []
+        for msg in self._messages:
+            sender = html.escape(msg["sender"])
+            if msg["markdown"]:
+                body = _markdown_to_basic_html(msg["body"])
+            else:
+                body = f"<p>{_plain_text_to_html(msg['body'])}</p>"
+            blocks.append(
+                "<div style='margin-bottom: 12px;'>"
+                f"<p style='font-weight: 600; margin-bottom: 4px;'>{sender}</p>"
+                f"{body}"
+                "</div>"
+            )
+        self.transcript.setHtml("\n".join(blocks))
+        end_cursor = getattr(getattr(QTextCursor, "MoveOperation", QTextCursor), "End")
+        self.transcript.moveCursor(end_cursor)
+
+    def _copy_latest_markdown(self):
+        """Copy the latest assistant Markdown response to the clipboard."""
+        if not self._last_assistant_markdown:
+            return
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText(self._last_assistant_markdown)
+            self.status_label.setText("Copied latest response as Markdown.")
+            self.status_label.setStyleSheet("color: green; font-size: 10px;")
+
+    def _clear_transcript(self):
+        """Clear all rendered chat messages."""
+        self._messages = []
+        self._last_assistant_markdown = ""
+        self.copy_md_btn.setEnabled(False)
+        self.transcript.clear()
+
+    def _shutdown_running_state(self):
+        """Stop the animated status timer when the dock is dismissed."""
+        try:
+            self._stop_running_status()
+        except Exception:  # nosec B110
+            pass
+
+    def hideEvent(self, event):
+        """Stop the animated status timer when the dock is hidden."""
+        self._shutdown_running_state()
+        super().hideEvent(event)
+
+    def closeEvent(self, event):
+        """Stop the animated status timer when the dock is closed."""
+        self._shutdown_running_state()
+        super().closeEvent(event)

--- a/gee_data_catalogs/dialogs/dependency_dialog.py
+++ b/gee_data_catalogs/dialogs/dependency_dialog.py
@@ -66,7 +66,8 @@ class DependencyDockWidget(QDockWidget):
         # Info label
         info = QLabel(
             "This plugin requires the <b>earthengine-api</b> and "
-            "<b>geemap</b> Python packages.<br><br>"
+            "<b>geemap</b> Python packages. The AI assistant also requires "
+            "<b>GeoAgent</b> and model provider clients.<br><br>"
             "Click 'Install Dependencies' to install them in an<br>"
             "isolated virtual environment at:<br>"
             "<code>~/.qgis_gee_data_catalogs/</code><br><br>"

--- a/gee_data_catalogs/dialogs/settings_dock.py
+++ b/gee_data_catalogs/dialogs/settings_dock.py
@@ -24,6 +24,14 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.PyQt.QtGui import QFont
 
+from .chat_dock import DEFAULT_MODELS, PROVIDERS
+
+
+def _enum_value(cls, enum_name, member_name):
+    """Return an enum member from either scoped or legacy Qt APIs."""
+    container = getattr(cls, enum_name, cls)
+    return getattr(container, member_name)
+
 
 class SettingsDockWidget(QDockWidget):
     """A settings panel for configuring plugin options."""
@@ -85,6 +93,9 @@ class SettingsDockWidget(QDockWidget):
         # Display tab
         display_tab = self._create_display_tab()
         self.tab_widget.addTab(display_tab, "Display")
+
+        model_tab = self._create_model_tab()
+        self.tab_widget.addTab(model_tab, "Model")
 
         # Buttons
         button_layout = QHBoxLayout()
@@ -293,6 +304,91 @@ class SettingsDockWidget(QDockWidget):
         layout.addStretch()
         return widget
 
+    def _create_model_tab(self):
+        """Create the AI model settings tab."""
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+
+        model_group = QGroupBox("AI Provider")
+        form = QFormLayout(model_group)
+
+        self.provider_combo = QComboBox()
+        self.provider_combo.addItems(PROVIDERS)
+        self.provider_combo.setMinimumContentsLength(10)
+        self.provider_combo.setSizeAdjustPolicy(
+            _enum_value(
+                QComboBox,
+                "SizeAdjustPolicy",
+                "AdjustToMinimumContentsLengthWithIcon",
+            )
+        )
+        self.provider_combo.currentTextChanged.connect(self._on_provider_changed)
+        form.addRow("Provider:", self.provider_combo)
+
+        self.model_input = QLineEdit()
+        self.model_input.setPlaceholderText("Provider default")
+        form.addRow("Model:", self.model_input)
+
+        self.fast_check = QCheckBox("Use fast GeoAgent prompt")
+        form.addRow("", self.fast_check)
+
+        self.max_tokens_spin = QSpinBox()
+        self.max_tokens_spin.setRange(256, 32768)
+        self.max_tokens_spin.setValue(4096)
+        self.max_tokens_spin.setSingleStep(256)
+        form.addRow("Max tokens:", self.max_tokens_spin)
+
+        layout.addWidget(model_group)
+
+        credentials_group = QGroupBox("Credentials and Hosts")
+        credentials_form = QFormLayout(credentials_group)
+
+        password_mode = getattr(getattr(QLineEdit, "EchoMode", QLineEdit), "Password")
+
+        self.openai_key_input = QLineEdit()
+        self.openai_key_input.setEchoMode(password_mode)
+        credentials_form.addRow("OpenAI API key:", self.openai_key_input)
+
+        self.anthropic_key_input = QLineEdit()
+        self.anthropic_key_input.setEchoMode(password_mode)
+        credentials_form.addRow("Anthropic API key:", self.anthropic_key_input)
+
+        self.gemini_key_input = QLineEdit()
+        self.gemini_key_input.setEchoMode(password_mode)
+        credentials_form.addRow("Gemini API key:", self.gemini_key_input)
+
+        self.aws_region_input = QLineEdit()
+        self.aws_region_input.setPlaceholderText("e.g. us-east-1")
+        credentials_form.addRow("AWS region:", self.aws_region_input)
+
+        self.ollama_host_input = QLineEdit()
+        self.ollama_host_input.setPlaceholderText("http://127.0.0.1:11434")
+        credentials_form.addRow("Ollama host:", self.ollama_host_input)
+
+        self.litellm_key_input = QLineEdit()
+        self.litellm_key_input.setEchoMode(password_mode)
+        credentials_form.addRow("LiteLLM API key:", self.litellm_key_input)
+
+        self.litellm_base_url_input = QLineEdit()
+        self.litellm_base_url_input.setPlaceholderText("https://proxy.example.com")
+        credentials_form.addRow("LiteLLM base URL:", self.litellm_base_url_input)
+
+        layout.addWidget(credentials_group)
+
+        note = QLabel(
+            "Credential values are saved in QGIS settings and applied to the "
+            "current QGIS process when the AI assistant runs."
+        )
+        note.setWordWrap(True)
+        note.setStyleSheet("font-size: 10px; color: gray;")
+        layout.addWidget(note)
+        layout.addStretch()
+        return widget
+
+    def _on_provider_changed(self, provider):
+        """Update the model field when the provider changes."""
+        self.model_input.setText(DEFAULT_MODELS.get(provider, ""))
+
     def _load_settings(self):
         """Load settings from QSettings."""
         # General
@@ -354,6 +450,46 @@ class SettingsDockWidget(QDockWidget):
             self.settings.value(f"{self.SETTINGS_PREFIX}stretch_type", 0, type=int)
         )
 
+        # AI model
+        provider = self.settings.value(
+            f"{self.SETTINGS_PREFIX}provider", "openai", type=str
+        )
+        provider_index = self.provider_combo.findText(provider)
+        self.provider_combo.setCurrentIndex(
+            provider_index if provider_index >= 0 else 1
+        )
+        model = self.settings.value(f"{self.SETTINGS_PREFIX}model", "", type=str)
+        self.model_input.setText(model or DEFAULT_MODELS.get(provider, ""))
+        self.fast_check.setChecked(
+            self.settings.value(f"{self.SETTINGS_PREFIX}fast_mode", False, type=bool)
+        )
+        self.max_tokens_spin.setValue(
+            self.settings.value(f"{self.SETTINGS_PREFIX}max_tokens", 4096, type=int)
+        )
+        self.openai_key_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}openai_api_key", "", type=str)
+        )
+        self.anthropic_key_input.setText(
+            self.settings.value(
+                f"{self.SETTINGS_PREFIX}anthropic_api_key", "", type=str
+            )
+        )
+        self.gemini_key_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}gemini_api_key", "", type=str)
+        )
+        self.aws_region_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}aws_region", "", type=str)
+        )
+        self.ollama_host_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}ollama_host", "", type=str)
+        )
+        self.litellm_key_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}litellm_api_key", "", type=str)
+        )
+        self.litellm_base_url_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}litellm_base_url", "", type=str)
+        )
+
         self.status_label.setText("Settings loaded")
         self.status_label.setStyleSheet("color: gray; font-size: 10px;")
 
@@ -413,6 +549,41 @@ class SettingsDockWidget(QDockWidget):
             f"{self.SETTINGS_PREFIX}stretch_type", self.stretch_type.currentIndex()
         )
 
+        # AI model
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}provider", self.provider_combo.currentText()
+        )
+        self.settings.setValue(f"{self.SETTINGS_PREFIX}model", self.model_input.text())
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}fast_mode", self.fast_check.isChecked()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}max_tokens", self.max_tokens_spin.value()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}openai_api_key", self.openai_key_input.text()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}anthropic_api_key",
+            self.anthropic_key_input.text(),
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}gemini_api_key", self.gemini_key_input.text()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}aws_region", self.aws_region_input.text()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}ollama_host", self.ollama_host_input.text()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}litellm_api_key", self.litellm_key_input.text()
+        )
+        self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}litellm_base_url",
+            self.litellm_base_url_input.text(),
+        )
+
         self.settings.sync()
 
         self.status_label.setText("Settings saved")
@@ -456,6 +627,19 @@ class SettingsDockWidget(QDockWidget):
         self.auto_zoom.setChecked(False)
         self.default_palette.setCurrentIndex(0)
         self.stretch_type.setCurrentIndex(0)
+
+        # AI model
+        self.provider_combo.setCurrentText("openai")
+        self.model_input.setText(DEFAULT_MODELS["openai"])
+        self.fast_check.setChecked(False)
+        self.max_tokens_spin.setValue(4096)
+        self.openai_key_input.clear()
+        self.anthropic_key_input.clear()
+        self.gemini_key_input.clear()
+        self.aws_region_input.clear()
+        self.ollama_host_input.clear()
+        self.litellm_key_input.clear()
+        self.litellm_base_url_input.clear()
 
         self.status_label.setText("Defaults restored (not saved)")
         self.status_label.setStyleSheet("color: orange; font-size: 10px;")

--- a/gee_data_catalogs/dialogs/settings_dock.py
+++ b/gee_data_catalogs/dialogs/settings_dock.py
@@ -455,11 +455,14 @@ class SettingsDockWidget(QDockWidget):
             f"{self.SETTINGS_PREFIX}provider", "openai", type=str
         )
         provider_index = self.provider_combo.findText(provider)
+        if provider_index < 0:
+            provider_index = self.provider_combo.findText("openai")
         self.provider_combo.setCurrentIndex(
-            provider_index if provider_index >= 0 else 1
+            provider_index if provider_index >= 0 else 0
         )
+        effective_provider = self.provider_combo.currentText()
         model = self.settings.value(f"{self.SETTINGS_PREFIX}model", "", type=str)
-        self.model_input.setText(model or DEFAULT_MODELS.get(provider, ""))
+        self.model_input.setText(model or DEFAULT_MODELS.get(effective_provider, ""))
         self.fast_check.setChecked(
             self.settings.value(f"{self.SETTINGS_PREFIX}fast_mode", False, type=bool)
         )

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -30,6 +30,7 @@ class GeeDataCatalogs:
 
         # Dock widgets (lazy loaded)
         self._catalog_dock = None
+        self._chat_dock = None
         self._settings_dock = None
         self._deps_dock = None
 
@@ -136,6 +137,15 @@ class GeeDataCatalogs:
             parent=self.iface.mainWindow(),
         )
 
+        self.chat_action = self.add_action(
+            main_icon,
+            "AI Assistant",
+            self.toggle_chat_dock,
+            status_tip="Open the GEE Data Catalogs AI assistant",
+            checkable=True,
+            parent=self.iface.mainWindow(),
+        )
+
         # Add Settings Panel action (checkable for dock toggle)
         self.settings_action = self.add_action(
             settings_icon,
@@ -195,6 +205,11 @@ class GeeDataCatalogs:
             self.iface.removeDockWidget(self._catalog_dock)
             self._catalog_dock.deleteLater()
             self._catalog_dock = None
+
+        if self._chat_dock:
+            self.iface.removeDockWidget(self._chat_dock)
+            self._chat_dock.deleteLater()
+            self._chat_dock = None
 
         if self._settings_dock:
             self.iface.removeDockWidget(self._settings_dock)
@@ -586,6 +601,45 @@ class GeeDataCatalogs:
     def _on_catalog_visibility_changed(self, visible):
         """Handle Catalog dock visibility change."""
         self.catalog_action.setChecked(visible)
+
+    def toggle_chat_dock(self):
+        """Toggle the AI assistant dock widget visibility."""
+        if self._chat_dock is not None:
+            if self._chat_dock.isVisible():
+                self._chat_dock.hide()
+            else:
+                self._chat_dock.show()
+                self._chat_dock.raise_()
+            return
+
+        self._ensure_dependencies(self._create_chat_dock)
+
+    def _create_chat_dock(self):
+        """Create and show the AI assistant dock after dependencies are ready."""
+        try:
+            from .dialogs.chat_dock import ChatDockWidget
+
+            self._chat_dock = ChatDockWidget(
+                self.iface, plugin=self, parent=self.iface.mainWindow()
+            )
+            self._chat_dock.setObjectName("GeeDataCatalogsChatDock")
+            self._chat_dock.visibilityChanged.connect(self._on_chat_visibility_changed)
+            self.iface.addDockWidget(
+                Qt.DockWidgetArea.RightDockWidgetArea, self._chat_dock
+            )
+            self._chat_dock.show()
+            self._chat_dock.raise_()
+        except Exception as e:
+            QMessageBox.critical(
+                self.iface.mainWindow(),
+                "Error",
+                f"Failed to create AI assistant panel:\n{str(e)}",
+            )
+            self.chat_action.setChecked(False)
+
+    def _on_chat_visibility_changed(self, visible):
+        """Handle AI assistant dock visibility change."""
+        self.chat_action.setChecked(visible)
 
     def toggle_settings_dock(self):
         """Toggle the Settings dock widget visibility (with dependency gate)."""

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -205,6 +205,9 @@ class GeeDataCatalogs:
 
         # Remove dock widgets
         if self._catalog_dock:
+            ai_tab = getattr(self._catalog_dock, "ai_assistant_tab", None)
+            if ai_tab is not None and hasattr(ai_tab, "shutdown"):
+                ai_tab.shutdown()
             self.iface.removeDockWidget(self._catalog_dock)
             self._catalog_dock.deleteLater()
             self._catalog_dock = None

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -30,7 +30,6 @@ class GeeDataCatalogs:
 
         # Dock widgets (lazy loaded)
         self._catalog_dock = None
-        self._chat_dock = None
         self._settings_dock = None
         self._deps_dock = None
 
@@ -109,6 +108,10 @@ class GeeDataCatalogs:
         if not os.path.exists(settings_icon):
             settings_icon = ":/images/themes/default/mActionOptions.svg"
 
+        robot_icon = os.path.join(icon_base, "robot.svg")
+        if not os.path.exists(robot_icon):
+            robot_icon = main_icon
+
         about_icon = os.path.join(icon_base, "about.svg")
         if not os.path.exists(about_icon):
             about_icon = ":/images/themes/default/mActionHelpContents.svg"
@@ -138,10 +141,10 @@ class GeeDataCatalogs:
         )
 
         self.chat_action = self.add_action(
-            main_icon,
+            robot_icon,
             "AI Assistant",
             self.toggle_chat_dock,
-            status_tip="Open the GEE Data Catalogs AI assistant",
+            status_tip="Open the AI Assistant tab in the GEE Data Catalogs panel",
             checkable=True,
             parent=self.iface.mainWindow(),
         )
@@ -205,11 +208,6 @@ class GeeDataCatalogs:
             self.iface.removeDockWidget(self._catalog_dock)
             self._catalog_dock.deleteLater()
             self._catalog_dock = None
-
-        if self._chat_dock:
-            self.iface.removeDockWidget(self._chat_dock)
-            self._chat_dock.deleteLater()
-            self._chat_dock = None
 
         if self._settings_dock:
             self.iface.removeDockWidget(self._settings_dock)
@@ -580,7 +578,9 @@ class GeeDataCatalogs:
         try:
             from .dialogs.catalog_dock import CatalogDockWidget
 
-            self._catalog_dock = CatalogDockWidget(self.iface, self.iface.mainWindow())
+            self._catalog_dock = CatalogDockWidget(
+                self.iface, plugin=self, parent=self.iface.mainWindow()
+            )
             self._catalog_dock.setObjectName("GeeDataCatalogsDock")
             self._catalog_dock.visibilityChanged.connect(
                 self._on_catalog_visibility_changed
@@ -600,46 +600,53 @@ class GeeDataCatalogs:
 
     def _on_catalog_visibility_changed(self, visible):
         """Handle Catalog dock visibility change."""
-        self.catalog_action.setChecked(visible)
+        self._sync_panel_actions()
 
     def toggle_chat_dock(self):
-        """Toggle the AI assistant dock widget visibility."""
-        if self._chat_dock is not None:
-            if self._chat_dock.isVisible():
-                self._chat_dock.hide()
-            else:
-                self._chat_dock.show()
-                self._chat_dock.raise_()
+        """Toggle the AI assistant tab in the main Catalog panel."""
+        if self._catalog_dock is not None and self._catalog_dock.isVisible():
+            current_tab = self._catalog_dock.tab_widget.currentWidget()
+            if current_tab == self._catalog_dock.ai_assistant_tab:
+                self._catalog_dock.hide()
+                return
+            self._catalog_dock.show_ai_assistant_tab()
+            self._sync_panel_actions()
             return
 
-        self._ensure_dependencies(self._create_chat_dock)
+        self._ensure_dependencies(self._show_ai_assistant_tab)
+
+    def _show_ai_assistant_tab(self):
+        """Create/show the main panel and switch to the AI assistant tab."""
+        if self._catalog_dock is None:
+            self._create_catalog_dock()
+        if self._catalog_dock is not None:
+            self._catalog_dock.show_ai_assistant_tab()
+        self._sync_panel_actions()
 
     def _create_chat_dock(self):
-        """Create and show the AI assistant dock after dependencies are ready."""
-        try:
-            from .dialogs.chat_dock import ChatDockWidget
-
-            self._chat_dock = ChatDockWidget(
-                self.iface, plugin=self, parent=self.iface.mainWindow()
-            )
-            self._chat_dock.setObjectName("GeeDataCatalogsChatDock")
-            self._chat_dock.visibilityChanged.connect(self._on_chat_visibility_changed)
-            self.iface.addDockWidget(
-                Qt.DockWidgetArea.RightDockWidgetArea, self._chat_dock
-            )
-            self._chat_dock.show()
-            self._chat_dock.raise_()
-        except Exception as e:
-            QMessageBox.critical(
-                self.iface.mainWindow(),
-                "Error",
-                f"Failed to create AI assistant panel:\n{str(e)}",
-            )
-            self.chat_action.setChecked(False)
+        """Backward-compatible entry point for opening the assistant tab."""
+        self._show_ai_assistant_tab()
 
     def _on_chat_visibility_changed(self, visible):
         """Handle AI assistant dock visibility change."""
-        self.chat_action.setChecked(visible)
+        self._sync_panel_actions()
+
+    def _sync_panel_actions(self):
+        """Synchronize toolbar/menu check states with the merged main panel."""
+        catalog_visible = bool(
+            self._catalog_dock is not None and self._catalog_dock.isVisible()
+        )
+        if hasattr(self, "catalog_action"):
+            self.catalog_action.setChecked(catalog_visible)
+
+        assistant_visible = False
+        if catalog_visible and hasattr(self._catalog_dock, "ai_assistant_tab"):
+            assistant_visible = (
+                self._catalog_dock.tab_widget.currentWidget()
+                == self._catalog_dock.ai_assistant_tab
+            )
+        if hasattr(self, "chat_action"):
+            self.chat_action.setChecked(assistant_visible)
 
     def toggle_settings_dock(self):
         """Toggle the Settings dock widget visibility (with dependency gate)."""

--- a/gee_data_catalogs/icons/robot.svg
+++ b/gee_data_catalogs/icons/robot.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <circle cx="24" cy="24" r="22" fill="#1A73E8"/>
+  <path d="M24 8v6" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="24" cy="7" r="3" fill="#34A853" stroke="#FFFFFF" stroke-width="1.5"/>
+  <rect x="11" y="16" width="26" height="21" rx="6" fill="#F8FBFF" stroke="#0B3D91" stroke-width="2"/>
+  <rect x="8" y="23" width="4" height="9" rx="2" fill="#F8FBFF" stroke="#0B3D91" stroke-width="1.5"/>
+  <rect x="36" y="23" width="4" height="9" rx="2" fill="#F8FBFF" stroke="#0B3D91" stroke-width="1.5"/>
+  <circle cx="18" cy="25" r="3" fill="#1A73E8"/>
+  <circle cx="30" cy="25" r="3" fill="#1A73E8"/>
+  <path d="M18 32h12" stroke="#34A853" stroke-width="2.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add a dockable AI assistant panel (`chat_dock.py`) that talks to a GeoAgent-backed agent for catalog search, dataset loading, and QGIS map actions, with prompt history, sample prompts, Markdown rendering, and a copy-as-Markdown button.
- Wire a new toolbar action and dock lifecycle into the main plugin and gate it behind the existing dependency installer.
- Extend the settings dock with a Model tab for provider, model, fast mode, max tokens, and per-provider credentials/hosts (OpenAI, Anthropic, Gemini, AWS, Ollama, LiteLLM).
- Add `GeoAgent[providers]` to the managed venv requirements and switch the venv health check to verify every required package via `importlib.metadata`.

## Test plan
- [ ] Launch QGIS, install plugin dependencies via the Dependencies panel, and confirm `GeoAgent` is reported as installed.
- [ ] Open the new "AI Assistant" toolbar action and verify the dock appears, toggles, and remembers visibility state.
- [ ] Configure a provider/key in Settings > Model, then send a sample prompt and confirm a response renders with tool/elapsed details.
- [ ] Switch providers in the dock and confirm the model field updates to the provider default; verify settings persist across QGIS restarts.
- [ ] Run `pre-commit run --all-files` and confirm Black, codespell, and Bandit all pass.