### PR TITLE
fix(ee): restore EE layer references on project reload (#53)

### DIFF
--- a/gee_data_catalogs/core/ee_utils.py
+++ b/gee_data_catalogs/core/ee_utils.py
@@ -268,6 +268,10 @@ def add_ee_layer(
         # Register the layer for Inspector (important: register before returning)
         add_ee_layer_to_registry(name, ee_object, vis_params)
 
+        # Persist EE metadata so the layer can be reconstructed on project reload.
+        if isinstance(layer, QgsRasterLayer):
+            _store_ee_layer_metadata(layer, ee_object, vis_params)
+
         return layer
     except ImportError:
         pass
@@ -380,6 +384,7 @@ def clear_ee_layer_registry():
 EE_ASSET_ID_KEY = "ee_asset_id"
 EE_VIS_PARAMS_KEY = "ee_vis_params"
 EE_OBJECT_TYPE_KEY = "ee_object_type"
+EE_SERIALIZED_KEY = "ee_serialized"
 
 
 def _store_ee_layer_metadata(
@@ -387,7 +392,11 @@ def _store_ee_layer_metadata(
 ) -> None:
     """Store Earth Engine metadata in layer custom properties.
 
-    This enables layer refresh when reopening a QGIS project.
+    This enables layer refresh when reopening a QGIS project. In addition to
+    the asset id (only present for pristine catalog assets), the full
+    Earth Engine computation graph is serialized so that derived/computed
+    objects produced from the Code tab can be reconstructed losslessly on
+    project reload.
 
     Args:
         layer: The QGIS layer to store metadata on.
@@ -429,9 +438,26 @@ def _store_ee_layer_metadata(
     if vis_params:
         layer.setCustomProperty(EE_VIS_PARAMS_KEY, json.dumps(vis_params))
 
+    # Persist the full EE computation graph so derived/computed objects (e.g.
+    # `image.normalizedDifference([...])` from the Code tab) can be restored
+    # on project reload, not just pristine catalog assets.
+    if object_type is not None:
+        try:
+            serialized = ee.serializer.toJSON(ee_object)
+            layer.setCustomProperty(EE_SERIALIZED_KEY, serialized)
+        except Exception as exc:
+            QgsMessageLog.logMessage(
+                f"Could not serialize EE object for layer '{layer.name()}': {exc}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
+            )
+
 
 def is_ee_layer(layer: QgsRasterLayer) -> bool:
     """Check if a layer is an Earth Engine layer.
+
+    A layer is treated as an EE layer if it carries either an asset id or
+    a serialized computation graph in its custom properties.
 
     Args:
         layer: The layer to check.
@@ -439,13 +465,20 @@ def is_ee_layer(layer: QgsRasterLayer) -> bool:
     Returns:
         True if the layer has EE metadata, False otherwise.
     """
-    return layer.customProperty(EE_ASSET_ID_KEY) is not None
+    return (
+        layer.customProperty(EE_ASSET_ID_KEY) is not None
+        or layer.customProperty(EE_SERIALIZED_KEY) is not None
+    )
 
 
 def refresh_ee_layer(layer: QgsRasterLayer) -> bool:
     """Refresh an Earth Engine layer's tile URL.
 
     Regenerates the tile URL from stored metadata and updates the layer source.
+    Reconstruction prefers the serialized computation graph (which round-trips
+    derived/computed objects like ``image.normalizedDifference([...])``) and
+    falls back to loading by asset id when only a pristine catalog asset was
+    persisted.
 
     Args:
         layer: The QGIS layer to refresh.
@@ -459,9 +492,10 @@ def refresh_ee_layer(layer: QgsRasterLayer) -> bool:
     # Get stored metadata
     asset_id = layer.customProperty(EE_ASSET_ID_KEY)
     object_type = layer.customProperty(EE_OBJECT_TYPE_KEY)
+    serialized = layer.customProperty(EE_SERIALIZED_KEY)
     vis_params_json = layer.customProperty(EE_VIS_PARAMS_KEY)
 
-    if not asset_id:
+    if not asset_id and not serialized:
         return False
 
     # Parse visualization parameters
@@ -473,8 +507,23 @@ def refresh_ee_layer(layer: QgsRasterLayer) -> bool:
             pass
 
     try:
-        # Load the EE object
-        ee_object = load_ee_asset(asset_id, object_type)
+        # Reconstruct the EE object. Prefer the serialized computation graph so
+        # derived objects survive a reload; fall back to asset-id loading.
+        ee_object = None
+        if serialized:
+            try:
+                ee_object = ee.deserializer.fromJSON(serialized)
+            except Exception as exc:
+                QgsMessageLog.logMessage(
+                    f"Failed to deserialize EE graph for '{layer.name()}', "
+                    f"falling back to asset id: {exc}",
+                    "GEE Data Catalogs",
+                    Qgis.MessageLevel.Info,
+                )
+        if ee_object is None and asset_id:
+            ee_object = load_ee_asset(asset_id, object_type)
+        if ee_object is None:
+            return False
 
         # Generate new tile URL
         if isinstance(ee_object, ee.FeatureCollection):

--- a/gee_data_catalogs/core/ee_utils.py
+++ b/gee_data_catalogs/core/ee_utils.py
@@ -525,6 +525,12 @@ def refresh_ee_layer(layer: QgsRasterLayer) -> bool:
         if ee_object is None:
             return False
 
+        # Register in the Inspector registry as soon as reconstruction succeeds.
+        # Tile-URL regeneration below is best-effort and may fail on transient
+        # EE/network issues; the registry must still reflect the live EE
+        # object so Export/Inspector remain functional.
+        add_ee_layer_to_registry(layer.name(), ee_object, vis_params)
+
         # Generate new tile URL
         if isinstance(ee_object, ee.FeatureCollection):
             # Handle FeatureCollection styling
@@ -551,9 +557,6 @@ def refresh_ee_layer(layer: QgsRasterLayer) -> bool:
         # Update layer source
         new_uri = f"type=xyz&url={tile_url}&zmax=24&zmin=0"
         layer.setDataSource(new_uri, layer.name(), "wms")
-
-        # Re-register in the Inspector registry
-        add_ee_layer_to_registry(layer.name(), ee_object, vis_params)
 
         QgsMessageLog.logMessage(
             f"Refreshed EE layer: {layer.name()}",
@@ -589,6 +592,72 @@ def refresh_all_ee_layers() -> int:
                 refreshed_count += 1
 
     return refreshed_count
+
+
+def rebuild_ee_layer_registry() -> int:
+    """Rebuild the in-memory EE layer registry from QGIS layer custom properties.
+
+    This is a lightweight counterpart to :func:`refresh_all_ee_layers`: it
+    reconstructs ``ee.Image`` / ``ee.ImageCollection`` / ``ee.FeatureCollection``
+    objects from the metadata stored on each ``QgsRasterLayer`` (via
+    ``ee.deserializer.fromJSON`` or the asset-id constructor) and registers them
+    so the Export/Inspector tabs can find them. It does **not** regenerate tile
+    URLs or call ``getMapId``, so it is safe to invoke from UI handlers like
+    tab-change or refresh-button click without triggering network requests.
+
+    Returns:
+        Number of layers added to the registry.
+    """
+    if ee is None:
+        return 0
+
+    project = QgsProject.instance()
+    rebuilt_count = 0
+
+    for layer in project.mapLayers().values():
+        if not (isinstance(layer, QgsRasterLayer) and is_ee_layer(layer)):
+            continue
+
+        asset_id = layer.customProperty(EE_ASSET_ID_KEY)
+        object_type = layer.customProperty(EE_OBJECT_TYPE_KEY)
+        serialized = layer.customProperty(EE_SERIALIZED_KEY)
+        vis_params_json = layer.customProperty(EE_VIS_PARAMS_KEY)
+
+        vis_params: Dict = {}
+        if vis_params_json:
+            try:
+                vis_params = json.loads(vis_params_json)
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        ee_object = None
+        if serialized:
+            try:
+                ee_object = ee.deserializer.fromJSON(serialized)
+            except Exception as exc:
+                QgsMessageLog.logMessage(
+                    f"Failed to deserialize EE graph for '{layer.name()}', "
+                    f"falling back to asset id: {exc}",
+                    "GEE Data Catalogs",
+                    Qgis.MessageLevel.Info,
+                )
+        if ee_object is None and asset_id:
+            try:
+                ee_object = load_ee_asset(asset_id, object_type)
+            except Exception as exc:
+                QgsMessageLog.logMessage(
+                    f"Could not reconstruct EE object for '{layer.name()}': {exc}",
+                    "GEE Data Catalogs",
+                    Qgis.MessageLevel.Warning,
+                )
+                continue
+        if ee_object is None:
+            continue
+
+        add_ee_layer_to_registry(layer.name(), ee_object, vis_params)
+        rebuilt_count += 1
+
+    return rebuilt_count
 
 
 def detect_asset_type(asset_id: str) -> str:

--- a/gee_data_catalogs/dialogs/catalog_dock.py
+++ b/gee_data_catalogs/dialogs/catalog_dock.py
@@ -4828,18 +4828,28 @@ class CatalogDockWidget(QDockWidget):
     def _refresh_export_layers(self):
         """Refresh the list of EE layers available for export.
 
-        When Earth Engine is initialized, also rebuild the in-memory layer
-        registry from QGIS layer custom properties so layers carried over
-        from a saved project are visible without manual re-add.
+        Rebuilds the in-memory registry from QGIS layer custom properties so
+        layers carried over from a saved project become visible without manual
+        re-add, then re-renders the dropdown. The rebuild is cheap (no
+        ``getMapId`` / network calls) and is therefore safe to invoke from UI
+        flows like tab change or refresh button click. Tile URLs are refreshed
+        elsewhere (project read, post manual EE init).
         """
-        from ..core.ee_utils import (
-            get_ee_layers,
-            is_ee_initialized,
-            refresh_all_ee_layers,
-        )
+        from ..core.ee_utils import is_ee_initialized, rebuild_ee_layer_registry
 
         if is_ee_initialized():
-            refresh_all_ee_layers()
+            rebuild_ee_layer_registry()
+
+        self._render_export_from_registry()
+
+    def _render_export_from_registry(self):
+        """Re-render the Export-tab layer dropdown from the current registry.
+
+        Lightweight UI-only update with no rebuild and no network calls. Use
+        when callers have already populated the registry and just need the
+        dropdown refreshed.
+        """
+        from ..core.ee_utils import get_ee_layers
 
         self.export_layer_combo.clear()
         ee_layers = get_ee_layers()
@@ -7363,18 +7373,28 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
     def _refresh_inspector_layers(self):
         """Refresh the count of registered Earth Engine layers.
 
-        When Earth Engine is initialized, also rebuild the in-memory layer
-        registry from QGIS layer custom properties so layers carried over
-        from a saved project become inspectable without manual re-add.
+        Rebuilds the in-memory registry from QGIS layer custom properties so
+        layers carried over from a saved project become inspectable without
+        manual re-add, then re-renders the Inspector status label. The rebuild
+        is cheap (no ``getMapId`` / network calls) and is therefore safe to
+        invoke from UI flows like Inspector toggle or refresh button click.
+        Tile URLs are refreshed elsewhere (project read, post manual EE init).
         """
-        from ..core.ee_utils import (
-            get_ee_layers,
-            is_ee_initialized,
-            refresh_all_ee_layers,
-        )
+        from ..core.ee_utils import is_ee_initialized, rebuild_ee_layer_registry
 
         if is_ee_initialized():
-            refresh_all_ee_layers()
+            rebuild_ee_layer_registry()
+
+        self._render_inspector_from_registry()
+
+    def _render_inspector_from_registry(self):
+        """Re-render the Inspector layer-count label from the current registry.
+
+        Lightweight UI-only update with no rebuild and no network calls. Use
+        when callers have already populated the registry and just need the
+        label refreshed.
+        """
+        from ..core.ee_utils import get_ee_layers
 
         ee_layers = get_ee_layers()
         count = len(ee_layers)

--- a/gee_data_catalogs/dialogs/catalog_dock.py
+++ b/gee_data_catalogs/dialogs/catalog_dock.py
@@ -4826,8 +4826,20 @@ class CatalogDockWidget(QDockWidget):
         return widget
 
     def _refresh_export_layers(self):
-        """Refresh the list of EE layers available for export."""
-        from ..core.ee_utils import get_ee_layers
+        """Refresh the list of EE layers available for export.
+
+        When Earth Engine is initialized, also rebuild the in-memory layer
+        registry from QGIS layer custom properties so layers carried over
+        from a saved project are visible without manual re-add.
+        """
+        from ..core.ee_utils import (
+            get_ee_layers,
+            is_ee_initialized,
+            refresh_all_ee_layers,
+        )
+
+        if is_ee_initialized():
+            refresh_all_ee_layers()
 
         self.export_layer_combo.clear()
         ee_layers = get_ee_layers()
@@ -7349,8 +7361,20 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         QMessageBox.critical(self, "Error", message)
 
     def _refresh_inspector_layers(self):
-        """Refresh the count of registered Earth Engine layers."""
-        from ..core.ee_utils import get_ee_layers
+        """Refresh the count of registered Earth Engine layers.
+
+        When Earth Engine is initialized, also rebuild the in-memory layer
+        registry from QGIS layer custom properties so layers carried over
+        from a saved project become inspectable without manual re-add.
+        """
+        from ..core.ee_utils import (
+            get_ee_layers,
+            is_ee_initialized,
+            refresh_all_ee_layers,
+        )
+
+        if is_ee_initialized():
+            refresh_all_ee_layers()
 
         ee_layers = get_ee_layers()
         count = len(ee_layers)

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -551,8 +551,12 @@ class GeeDataCatalogs:
 
             # Restore any EE layers that were waiting for EE to be initialized
             # (e.g. project was opened before EE was authenticated this session).
+            # `refresh_all_ee_layers` regenerates tile URLs and registers each
+            # reconstructed EE object in the registry as a side effect. The
+            # dock UI is then re-rendered directly from the populated registry
+            # to avoid a redundant project-wide rebuild pass.
             try:
-                from .core.ee_utils import refresh_all_ee_layers
+                from .core.ee_utils import get_ee_layers, refresh_all_ee_layers
 
                 refreshed = refresh_all_ee_layers()
                 if refreshed:
@@ -560,11 +564,11 @@ class GeeDataCatalogs:
                         "GEE Data Catalogs",
                         f"Restored {refreshed} Earth Engine layer(s) from project.",
                     )
-                if self._catalog_dock:
-                    if hasattr(self._catalog_dock, "_refresh_inspector_layers"):
-                        self._catalog_dock._refresh_inspector_layers()
-                    if hasattr(self._catalog_dock, "_refresh_export_layers"):
-                        self._catalog_dock._refresh_export_layers()
+                if self._catalog_dock and get_ee_layers():
+                    if hasattr(self._catalog_dock, "_render_inspector_from_registry"):
+                        self._catalog_dock._render_inspector_from_registry()
+                    if hasattr(self._catalog_dock, "_render_export_from_registry"):
+                        self._catalog_dock._render_export_from_registry()
             except Exception as restore_exc:
                 from qgis.core import QgsMessageLog, Qgis
 

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -480,7 +480,7 @@ class GeeDataCatalogs:
                     self.iface.messageBar().pushWarning(
                         "GEE Data Catalogs",
                         f"Found {len(ee_layers)} Earth Engine layer(s) but EE is not initialized. "
-                        "Please initialize Earth Engine to refresh the layers.",
+                        "Initialize Earth Engine to automatically restore the layers.",
                     )
                     return
 
@@ -548,6 +548,31 @@ class GeeDataCatalogs:
             if project_source:
                 success_msg += f" (using project from {project_source})"
             self.iface.messageBar().pushSuccess("GEE Data Catalogs", success_msg)
+
+            # Restore any EE layers that were waiting for EE to be initialized
+            # (e.g. project was opened before EE was authenticated this session).
+            try:
+                from .core.ee_utils import refresh_all_ee_layers
+
+                refreshed = refresh_all_ee_layers()
+                if refreshed:
+                    self.iface.messageBar().pushSuccess(
+                        "GEE Data Catalogs",
+                        f"Restored {refreshed} Earth Engine layer(s) from project.",
+                    )
+                if self._catalog_dock:
+                    if hasattr(self._catalog_dock, "_refresh_inspector_layers"):
+                        self._catalog_dock._refresh_inspector_layers()
+                    if hasattr(self._catalog_dock, "_refresh_export_layers"):
+                        self._catalog_dock._refresh_export_layers()
+            except Exception as restore_exc:
+                from qgis.core import QgsMessageLog, Qgis
+
+                QgsMessageLog.logMessage(
+                    f"Failed to restore EE layers after init: {restore_exc}",
+                    "GEE Data Catalogs",
+                    Qgis.MessageLevel.Warning,
+                )
         except ImportError as e:
             QMessageBox.critical(
                 self.iface.mainWindow(),


### PR DESCRIPTION
## Summary

Closes #53. After a QGIS project containing Earth Engine layers was saved and reopened, the plugin's in-memory `_ee_layer_registry` was empty: the Export tab dropdown showed "No EE layers loaded", the Inspector "Refresh Layers" button could not recover, and Code-tab derived layers could not be reconstructed at all because their `system:id` was `None`.

This change:

- Persists the full EE computation graph as a `QgsRasterLayer` custom property via `ee.serializer.toJSON`, so both pristine catalog assets (e.g. Dynamic World 2023) and derived/computed objects from the Code tab survive a reload.
- Extends `is_ee_layer` and `refresh_ee_layer` to recognize the serialized graph and prefer it over the asset-id path on reconstruction.
- Wires the Inspector and Export tab "Refresh" buttons to actually rebuild the registry from layer custom properties (previously they only re-rendered the count from the already-empty in-memory dict).
- Auto-runs `refresh_all_ee_layers()` after a successful manual EE initialization, so users who deferred auth on project open recover their layers without an extra click.
- Stores EE metadata when `qgis_geemap` is the layer creator (previously only the fallback path called `_store_ee_layer_metadata`).

The serialized payload is small (~150 bytes for a pristine asset, under 1 KB for a typical Code-tab NDVI computation).

## Test plan

- [x] `pre-commit run --all-files`
- [x] `pytest tests/` (16 passed)
- [x] Verified `ee.serializer.toJSON` / `ee.deserializer.fromJSON` round-trip for pristine `ee.Image('USGS/SRTMGL1_003')` and for a Code-tab style derived `ee.Image` (`collection.median().normalizedDifference([...])`)
- [ ] Manual repro from the issue: add Dynamic World 2023, save project, reopen QGIS; confirm Export dropdown lists the layer
- [ ] With auto-init disabled (clear `EE_PROJECT_ID` and plugin project setting): reopen project, click "Initialize Earth Engine", confirm layers are restored automatically
- [ ] Code-tab repro: add a derived NDVI layer via `m.add_layer(ndvi, ...)`, save, reopen; confirm Inspector can probe values at clicked points