### PR TITLE
feat(ai): add ChatGPT Codex login and resilient EE XYZ fallback

### DIFF
--- a/gee_data_catalogs/core/ee_utils.py
+++ b/gee_data_catalogs/core/ee_utils.py
@@ -7,6 +7,7 @@ This module provides utility functions for working with Earth Engine in QGIS.
 import json
 import os
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 
 try:
     import ee
@@ -25,6 +26,12 @@ _ee_initialized = False
 
 # Global registry to track EE layers for Inspector
 _ee_layer_registry = {}
+
+
+def _xyz_uri_from_tile_url(tile_url: str) -> str:
+    """Return a QGIS XYZ datasource URI with the nested tile URL encoded."""
+    encoded_url = quote(tile_url, safe=":/{}")
+    return f"type=xyz&url={encoded_url}&zmax=24&zmin=0"
 
 
 def _normalize_ee_asset_type(asset_type: str) -> str:
@@ -211,6 +218,49 @@ def get_ee_tile_url(
     return tile_url
 
 
+def _is_valid_qgis_layer(layer: Any) -> bool:
+    """Return True when ``layer`` is a valid QGIS raster layer."""
+    if not isinstance(layer, QgsRasterLayer):
+        return False
+    try:
+        return bool(layer.isValid())
+    except Exception:  # nosec B110
+        return False
+
+
+def _create_xyz_ee_layer(
+    ee_object: Any,
+    vis_params: Dict,
+    name: str,
+) -> QgsRasterLayer:
+    """Create a QGIS XYZ raster layer for an Earth Engine object."""
+    if isinstance(ee_object, (ee.Image, ee.ImageCollection)):
+        tile_url = get_ee_tile_url(ee_object, vis_params)
+        uri = _xyz_uri_from_tile_url(tile_url)
+        return QgsRasterLayer(uri, name, "wms")
+
+    if isinstance(ee_object, ee.FeatureCollection):
+        valid_style_keys = {
+            "color",
+            "pointSize",
+            "pointShape",
+            "width",
+            "fillColor",
+            "styleProperty",
+            "neighborhood",
+            "lineType",
+        }
+        style_params = {k: v for k, v in vis_params.items() if k in valid_style_keys}
+        styled_fc = ee_object
+        if style_params:
+            styled_fc = ee_object.style(**style_params)
+        tile_url = get_ee_tile_url(styled_fc, {})
+        uri = _xyz_uri_from_tile_url(tile_url)
+        return QgsRasterLayer(uri, name, "wms")
+
+    raise TypeError(f"Unsupported Earth Engine object type: {type(ee_object)}")
+
+
 def add_ee_layer(
     ee_object: Any,
     vis_params: Optional[Dict] = None,
@@ -253,13 +303,34 @@ def add_ee_layer(
     if iface and iface.mapCanvas():
         current_extent = iface.mapCanvas().extent()
 
-    # Try to use qgis_geemap if available
+    # Try to use qgis_geemap if available, but fall back to direct XYZ tiles
+    # when it returns no layer or an invalid layer.
+    layer = None
     try:
         from qgis_geemap.core.qgis_map import Map
 
         m = Map()
         layer = m.add_layer(ee_object, vis_params, name, shown, opacity)
+        if not _is_valid_qgis_layer(layer):
+            QgsMessageLog.logMessage(
+                f"qgis_geemap did not create a valid layer for '{name}'. "
+                "Falling back to direct Earth Engine XYZ tiles.",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
+            )
+            layer = None
+    except ImportError:
+        layer = None
+    except Exception as exc:
+        QgsMessageLog.logMessage(
+            f"qgis_geemap failed for '{name}': {exc}. Falling back to direct "
+            "Earth Engine XYZ tiles.",
+            "GEE Data Catalogs",
+            Qgis.MessageLevel.Warning,
+        )
+        layer = None
 
+    if layer is not None:
         # Restore the map extent after qgis_geemap adds the layer
         if current_extent and iface and iface.mapCanvas():
             iface.mapCanvas().setExtent(current_extent)
@@ -273,38 +344,8 @@ def add_ee_layer(
             _store_ee_layer_metadata(layer, ee_object, vis_params)
 
         return layer
-    except ImportError:
-        pass
 
-    # Fallback: Handle different EE object types
-    if isinstance(ee_object, (ee.Image, ee.ImageCollection)):
-        tile_url = get_ee_tile_url(ee_object, vis_params)
-        uri = f"type=xyz&url={tile_url}&zmax=24&zmin=0"
-        layer = QgsRasterLayer(uri, name, "wms")
-    elif isinstance(ee_object, ee.FeatureCollection):
-        # For FeatureCollection, render as styled tiles
-        # Filter out params not supported by FeatureCollection.style()
-        # style() accepts: color, pointSize, pointShape, width, fillColor, styleProperty, neighborhood, lineType
-        valid_style_keys = {
-            "color",
-            "pointSize",
-            "pointShape",
-            "width",
-            "fillColor",
-            "styleProperty",
-            "neighborhood",
-            "lineType",
-        }
-        style_params = {k: v for k, v in vis_params.items() if k in valid_style_keys}
-
-        styled_fc = ee_object
-        if style_params:
-            styled_fc = ee_object.style(**style_params)
-        tile_url = get_ee_tile_url(styled_fc, {})
-        uri = f"type=xyz&url={tile_url}&zmax=24&zmin=0"
-        layer = QgsRasterLayer(uri, name, "wms")
-    else:
-        raise TypeError(f"Unsupported Earth Engine object type: {type(ee_object)}")
+    layer = _create_xyz_ee_layer(ee_object, vis_params, name)
 
     if not layer.isValid():
         raise ValueError(f"Failed to create valid layer: {name}")
@@ -555,7 +596,7 @@ def refresh_ee_layer(layer: QgsRasterLayer) -> bool:
             tile_url = get_ee_tile_url(ee_object, vis_params)
 
         # Update layer source
-        new_uri = f"type=xyz&url={tile_url}&zmax=24&zmin=0"
+        new_uri = _xyz_uri_from_tile_url(tile_url)
         layer.setDataSource(new_uri, layer.name(), "wms")
 
         QgsMessageLog.logMessage(

--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -27,15 +27,25 @@ from qgis.PyQt.QtWidgets import (
 )
 
 SETTINGS_PREFIX = "GeeDataCatalogs/"
+DEFAULT_PROVIDER = "openai-codex"
 DEFAULT_MODELS = {
     "bedrock": "us.anthropic.claude-sonnet-4-6",
     "openai": "gpt-5.5",
+    "openai-codex": "gpt-5.5",
     "anthropic": "claude-sonnet-4-6",
     "gemini": "gemini-3.1-pro-preview",
     "ollama": "qwen3.5:4b",
     "litellm": "openai/gpt-5.5",
 }
-PROVIDERS = ["bedrock", "openai", "anthropic", "gemini", "ollama", "litellm"]
+PROVIDERS = [
+    "bedrock",
+    "openai",
+    "openai-codex",
+    "anthropic",
+    "gemini",
+    "ollama",
+    "litellm",
+]
 MAX_CONTEXT_MESSAGES = 12
 MAX_CONTEXT_CHARS = 12000
 SAMPLE_PROMPTS = [
@@ -68,14 +78,11 @@ def _apply_environment_from_settings(settings):
     }
     for key, env_names in env_map.items():
         value = _setting(settings, key, "").strip()
-        if isinstance(env_names, str):
-            env_names = (env_names,)
         if value:
+            if isinstance(env_names, str):
+                env_names = (env_names,)
             for env_name in env_names:
                 os.environ[env_name] = value
-        else:
-            for env_name in env_names:
-                os.environ.pop(env_name, None)
 
 
 def _qt_value(enum_name, member_name):
@@ -179,6 +186,18 @@ def _markdown_to_basic_html(markdown):
         )
     close_lists()
     return "\n".join(html_lines)
+
+
+def _conversation_markdown(messages):
+    """Return the full chat transcript as Markdown."""
+    blocks = []
+    for msg in messages:
+        sender = str(msg.get("sender") or "").strip()
+        body = str(msg.get("body") or "").strip()
+        if not sender or not body:
+            continue
+        blocks.append(f"## {sender}\n\n{body}")
+    return "\n\n".join(blocks)
 
 
 class PromptTextEdit(QPlainTextEdit):
@@ -320,7 +339,6 @@ class ChatPanelWidget(QWidget):
         self._prompt_history = []
         self._history_index = None
         self._messages = []
-        self._last_assistant_markdown = ""
         self._status_started_at = None
         self._status_base_text = "Running"
         self._status_frame = 0
@@ -407,7 +425,7 @@ class ChatPanelWidget(QWidget):
 
         self.copy_md_btn = QPushButton("Copy Markdown")
         self.copy_md_btn.setEnabled(False)
-        self.copy_md_btn.clicked.connect(self._copy_latest_markdown)
+        self.copy_md_btn.clicked.connect(self._copy_transcript_markdown)
         button_layout.addWidget(self.copy_md_btn)
         layout.addLayout(button_layout)
 
@@ -418,10 +436,10 @@ class ChatPanelWidget(QWidget):
 
     def _load_settings(self):
         """Load persisted model settings into the dock controls."""
-        provider = _setting(self.settings, "provider", "openai")
+        provider = _setting(self.settings, "provider", DEFAULT_PROVIDER)
         index = self.provider_combo.findText(provider)
         if index < 0:
-            index = self.provider_combo.findText("openai")
+            index = self.provider_combo.findText(DEFAULT_PROVIDER)
         self.provider_combo.setCurrentIndex(index if index >= 0 else 0)
 
         model = _setting(self.settings, "model", "")
@@ -457,9 +475,26 @@ class ChatPanelWidget(QWidget):
             )
             return
 
+        provider = self.provider_combo.currentText()
         self._save_model_settings()
-        self._record_prompt(prompt)
         _apply_environment_from_settings(self.settings)
+        if provider == "openai-codex":
+            try:
+                from ..oauth import ensure_openai_oauth_environment
+
+                ensure_openai_oauth_environment(
+                    self.settings,
+                    codex=True,
+                )
+            except Exception as exc:
+                QMessageBox.critical(
+                    self,
+                    "GEE Data Catalogs",
+                    f"OpenAI OAuth is not ready:\n\n{exc}",
+                )
+                return
+
+        self._record_prompt(prompt)
 
         try:
             from ..core.venv_manager import ensure_venv_packages_available
@@ -473,8 +508,9 @@ class ChatPanelWidget(QWidget):
             )
             return
 
-        provider = self.provider_combo.currentText()
-        model_id = self.model_input.text().strip()
+        model_id = self.model_input.text().strip() or DEFAULT_MODELS.get(provider, "")
+        if model_id and not self.model_input.text().strip():
+            self.model_input.setText(model_id)
         fast = self.fast_check.isChecked()
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
         prompt_with_context = self._build_prompt_with_context(prompt)
@@ -629,9 +665,7 @@ class ChatPanelWidget(QWidget):
         """Append a chat message and refresh the transcript."""
         body = message.strip()
         self._messages.append({"sender": sender, "body": body, "markdown": markdown})
-        if markdown:
-            self._last_assistant_markdown = body
-            self.copy_md_btn.setEnabled(True)
+        self.copy_md_btn.setEnabled(bool(self._messages))
         self._render_transcript()
 
     def _render_transcript(self):
@@ -653,20 +687,20 @@ class ChatPanelWidget(QWidget):
         end_cursor = getattr(getattr(QTextCursor, "MoveOperation", QTextCursor), "End")
         self.transcript.moveCursor(end_cursor)
 
-    def _copy_latest_markdown(self):
-        """Copy the latest assistant Markdown response to the clipboard."""
-        if not self._last_assistant_markdown:
+    def _copy_transcript_markdown(self):
+        """Copy the full chat transcript to the clipboard as Markdown."""
+        transcript = _conversation_markdown(self._messages)
+        if not transcript:
             return
         clipboard = QGuiApplication.clipboard()
         if clipboard is not None:
-            clipboard.setText(self._last_assistant_markdown)
-            self.status_label.setText("Copied latest response as Markdown.")
+            clipboard.setText(transcript)
+            self.status_label.setText("Copied chat history as Markdown.")
             self.status_label.setStyleSheet("color: green; font-size: 10px;")
 
     def _clear_transcript(self):
         """Clear all rendered chat messages."""
         self._messages = []
-        self._last_assistant_markdown = ""
         self.copy_md_btn.setEnabled(False)
         self.transcript.clear()
 

--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -239,7 +239,7 @@ def _extract_earth_engine_snippets(value):
             for parser in (json.loads, ast.literal_eval):
                 try:
                     parsed = parser(text)
-                except Exception:
+                except Exception:  # nosec B112
                     continue
                 _walk(parsed)
                 return

--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -1,6 +1,8 @@
 """Dockable AI assistant for the GEE Data Catalogs plugin."""
 
+import ast
 import html
+import json
 import os
 import re
 import time
@@ -200,6 +202,52 @@ def _conversation_markdown(messages):
     return "\n\n".join(blocks)
 
 
+def _extract_python_code_blocks(text):
+    """Return Python fenced code blocks from Markdown text."""
+    if not text:
+        return []
+    snippets = []
+    for match in re.finditer(r"```(?:python|py)?\s*\n(.*?)```", text, re.DOTALL):
+        code = match.group(1).strip()
+        if "ee." in code or "earthengine" in code.lower():
+            snippets.append(code)
+    return snippets
+
+
+def _extract_earth_engine_snippets(value):
+    """Extract Earth Engine Python snippets from nested tool-call metadata."""
+    snippets = []
+
+    def _walk(item):
+        if item is None:
+            return
+        if isinstance(item, dict):
+            snippet = item.get("earth_engine_python_snippet")
+            if isinstance(snippet, str) and snippet.strip():
+                snippets.append(snippet.strip())
+            for child in item.values():
+                _walk(child)
+            return
+        if isinstance(item, (list, tuple)):
+            for child in item:
+                _walk(child)
+            return
+        if isinstance(item, str):
+            text = item.strip()
+            if "earth_engine_python_snippet" not in text:
+                return
+            for parser in (json.loads, ast.literal_eval):
+                try:
+                    parsed = parser(text)
+                except Exception:
+                    continue
+                _walk(parsed)
+                return
+
+    _walk(value)
+    return snippets
+
+
 class PromptTextEdit(QPlainTextEdit):
     """Prompt editor with chat-friendly keyboard shortcuts."""
 
@@ -304,6 +352,9 @@ class ChatWorker(QThread):
                 )
 
             response = agent.chat(self.prompt)
+            snippets = _extract_earth_engine_snippets(response.tool_calls)
+            if not snippets:
+                snippets = _extract_python_code_blocks(response.answer_text or "")
             self.finished.emit(
                 {
                     "success": bool(response.success),
@@ -312,6 +363,7 @@ class ChatWorker(QThread):
                     "tools": ", ".join(response.executed_tools or []),
                     "cancelled": ", ".join(response.cancelled_tools or []),
                     "elapsed": f"{response.execution_time:.2f}s",
+                    "snippets": snippets,
                 }
             )
         except Exception as exc:
@@ -339,6 +391,7 @@ class ChatPanelWidget(QWidget):
         self._prompt_history = []
         self._history_index = None
         self._messages = []
+        self._latest_snippet = ""
         self._status_started_at = None
         self._status_base_text = "Running"
         self._status_frame = 0
@@ -427,6 +480,11 @@ class ChatPanelWidget(QWidget):
         self.copy_md_btn.setEnabled(False)
         self.copy_md_btn.clicked.connect(self._copy_transcript_markdown)
         button_layout.addWidget(self.copy_md_btn)
+
+        self.copy_snippet_btn = QPushButton("Copy Snippet")
+        self.copy_snippet_btn.setEnabled(False)
+        self.copy_snippet_btn.clicked.connect(self._copy_latest_snippet)
+        button_layout.addWidget(self.copy_snippet_btn)
         layout.addLayout(button_layout)
 
         self.status_label = QLabel("Ready. Ctrl+Enter sends. Up/Down cycles prompts.")
@@ -515,6 +573,8 @@ class ChatPanelWidget(QWidget):
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
         prompt_with_context = self._build_prompt_with_context(prompt)
 
+        self._latest_snippet = ""
+        self.copy_snippet_btn.setEnabled(False)
         self._append_message("You", prompt, markdown=False)
         self.prompt_input.clear()
         self.status_label.setStyleSheet("color: #1976D2; font-size: 10px;")
@@ -604,6 +664,13 @@ class ChatPanelWidget(QWidget):
         self._stop_running_status()
         if result.get("success"):
             answer = result.get("answer") or "(No text response.)"
+            snippets = result.get("snippets") or []
+            if snippets:
+                self._latest_snippet = snippets[-1]
+                self.copy_snippet_btn.setEnabled(True)
+            else:
+                self._latest_snippet = ""
+                self.copy_snippet_btn.setEnabled(False)
             details = []
             if result.get("tools"):
                 details.append(f"Tools: {result['tools']}")
@@ -615,6 +682,8 @@ class ChatPanelWidget(QWidget):
             self.status_label.setText("Ready")
             self.status_label.setStyleSheet("color: gray; font-size: 10px;")
         else:
+            self._latest_snippet = ""
+            self.copy_snippet_btn.setEnabled(False)
             error = result.get("error") or "Unknown error"
             cancelled = result.get("cancelled")
             if cancelled:
@@ -698,10 +767,22 @@ class ChatPanelWidget(QWidget):
             self.status_label.setText("Copied chat history as Markdown.")
             self.status_label.setStyleSheet("color: green; font-size: 10px;")
 
+    def _copy_latest_snippet(self):
+        """Copy the latest Earth Engine Python snippet to the clipboard."""
+        if not self._latest_snippet:
+            return
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText(self._latest_snippet)
+            self.status_label.setText("Copied Earth Engine Python snippet.")
+            self.status_label.setStyleSheet("color: green; font-size: 10px;")
+
     def _clear_transcript(self):
         """Clear all rendered chat messages."""
         self._messages = []
+        self._latest_snippet = ""
         self.copy_md_btn.setEnabled(False)
+        self.copy_snippet_btn.setEnabled(False)
         self.transcript.clear()
 
     def _shutdown_running_state(self):

--- a/gee_data_catalogs/dialogs/settings_dock.py
+++ b/gee_data_catalogs/dialogs/settings_dock.py
@@ -4,7 +4,10 @@ Settings Dock Widget for GEE Data Catalogs
 This module provides a settings panel for configuring plugin options.
 """
 
-from qgis.PyQt.QtCore import Qt, QSettings, pyqtSignal
+import os
+import time
+
+from qgis.PyQt.QtCore import Qt, QSettings, QThread, QUrl, pyqtSignal
 from qgis.PyQt.QtWidgets import (
     QDockWidget,
     QWidget,
@@ -22,15 +25,105 @@ from qgis.PyQt.QtWidgets import (
     QMessageBox,
     QTabWidget,
 )
-from qgis.PyQt.QtGui import QFont
+from qgis.PyQt.QtGui import QDesktopServices, QFont
 
-from .chat_dock import DEFAULT_MODELS, PROVIDERS
+from .chat_dock import DEFAULT_MODELS, DEFAULT_PROVIDER, PROVIDERS
+from ..oauth import (
+    CODEX_DEFAULT_CONFIG,
+    OPENAI_CODEX_AUTH_EXTRA_PARAMS,
+    OPENAI_CODEX_CALLBACK_PATH,
+    OPENAI_CODEX_CALLBACK_PORT,
+    clear_token_payload,
+    store_token_payload,
+)
+
+ENV_FALLBACKS = {
+    "openai_api_key": ("OPENAI_API_KEY",),
+    "anthropic_api_key": ("ANTHROPIC_API_KEY",),
+    "gemini_api_key": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    "aws_region": ("AWS_REGION", "AWS_DEFAULT_REGION"),
+    "ollama_host": ("OLLAMA_HOST",),
+    "litellm_api_key": ("LITELLM_API_KEY",),
+    "litellm_base_url": ("LITELLM_BASE_URL",),
+}
 
 
 def _enum_value(cls, enum_name, member_name):
     """Return an enum member from either scoped or legacy Qt APIs."""
     container = getattr(cls, enum_name, cls)
     return getattr(container, member_name)
+
+
+def _env_fallback(*env_names):
+    """Return the first non-empty environment value from ``env_names``."""
+    for env_name in env_names:
+        value = os.environ.get(env_name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+class OAuthLoginWorker(QThread):
+    """Run an OpenAI OAuth login flow without blocking QGIS."""
+
+    auth_url = pyqtSignal(str)
+    finished = pyqtSignal(dict)
+
+    def __init__(self, config, parent=None):
+        super().__init__(parent)
+        self.config = dict(config)
+
+    def run(self):
+        """Open a loopback OAuth flow and exchange the callback code."""
+        try:
+            from ..oauth import complete_loopback_flow, start_loopback_flow
+
+            is_codex = bool(self.config.get("codex"))
+            flow = start_loopback_flow(
+                self.config["authorization_url"],
+                client_id=self.config["client_id"],
+                scope=self.config.get("scope", ""),
+                redirect_host="localhost" if is_codex else "127.0.0.1",
+                port=OPENAI_CODEX_CALLBACK_PORT if is_codex else 0,
+                callback_path=OPENAI_CODEX_CALLBACK_PATH if is_codex else "/callback",
+                extra_params=OPENAI_CODEX_AUTH_EXTRA_PARAMS if is_codex else None,
+                fallback_port=not is_codex,
+            )
+            self.auth_url.emit(flow.authorization_url)
+            token = complete_loopback_flow(
+                flow,
+                token_url=self.config["token_url"],
+                client_id=self.config["client_id"],
+            )
+            self.finished.emit({"success": True, "token": token, "error": ""})
+        except Exception as exc:
+            self.finished.emit({"success": False, "token": {}, "error": str(exc)})
+
+
+class OAuthRefreshWorker(QThread):
+    """Refresh OpenAI OAuth tokens without blocking QGIS."""
+
+    finished = pyqtSignal(dict)
+
+    def __init__(self, config, refresh_token, parent=None):
+        super().__init__(parent)
+        self.config = dict(config)
+        self.refresh_token = refresh_token
+
+    def run(self):
+        """Refresh the OAuth token."""
+        try:
+            from ..oauth import refresh_oauth_token
+
+            token = refresh_oauth_token(
+                self.config["token_url"],
+                client_id=self.config["client_id"],
+                refresh_token=self.refresh_token,
+                scope=self.config.get("scope", ""),
+            )
+            self.finished.emit({"success": True, "token": token, "error": ""})
+        except Exception as exc:
+            self.finished.emit({"success": False, "token": {}, "error": str(exc)})
 
 
 class SettingsDockWidget(QDockWidget):
@@ -51,6 +144,8 @@ class SettingsDockWidget(QDockWidget):
         super().__init__("GEE Data Catalogs Settings", parent)
         self.iface = iface
         self.settings = QSettings()
+        self._oauth_worker = None
+        self._env_sourced_credentials = {}
 
         self.setAllowedAreas(
             Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
@@ -374,6 +469,46 @@ class SettingsDockWidget(QDockWidget):
         credentials_form.addRow("LiteLLM base URL:", self.litellm_base_url_input)
 
         layout.addWidget(credentials_group)
+        self._credential_inputs = (
+            ("openai_api_key", self.openai_key_input),
+            ("anthropic_api_key", self.anthropic_key_input),
+            ("gemini_api_key", self.gemini_key_input),
+            ("aws_region", self.aws_region_input),
+            ("ollama_host", self.ollama_host_input),
+            ("litellm_api_key", self.litellm_key_input),
+            ("litellm_base_url", self.litellm_base_url_input),
+        )
+
+        oauth_group = QGroupBox("ChatGPT Login")
+        oauth_form = QFormLayout(oauth_group)
+
+        oauth_note = QLabel(
+            "Login opens ChatGPT in your browser using the Codex OAuth flow."
+        )
+        oauth_note.setWordWrap(True)
+        oauth_note.setStyleSheet("font-size: 10px; color: gray;")
+        oauth_form.addRow(oauth_note)
+
+        oauth_button_layout = QHBoxLayout()
+        self.openai_oauth_login_btn = QPushButton("Login with ChatGPT")
+        self.openai_oauth_login_btn.clicked.connect(self._login_openai_oauth)
+        oauth_button_layout.addWidget(self.openai_oauth_login_btn)
+
+        self.openai_oauth_refresh_btn = QPushButton("Refresh")
+        self.openai_oauth_refresh_btn.clicked.connect(self._refresh_openai_oauth)
+        oauth_button_layout.addWidget(self.openai_oauth_refresh_btn)
+
+        self.openai_oauth_logout_btn = QPushButton("Logout")
+        self.openai_oauth_logout_btn.clicked.connect(self._logout_openai_oauth)
+        oauth_button_layout.addWidget(self.openai_oauth_logout_btn)
+        oauth_form.addRow("", oauth_button_layout)
+
+        self.openai_oauth_status_label = QLabel("Not logged in")
+        self.openai_oauth_status_label.setWordWrap(True)
+        self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: gray;")
+        oauth_form.addRow("Status:", self.openai_oauth_status_label)
+
+        layout.addWidget(oauth_group)
 
         note = QLabel(
             "Credential values are saved in QGIS settings and applied to the "
@@ -385,9 +520,141 @@ class SettingsDockWidget(QDockWidget):
         layout.addStretch()
         return widget
 
+    def _oauth_config(self):
+        """Return the built-in ChatGPT/Codex login settings."""
+        config = dict(CODEX_DEFAULT_CONFIG)
+        config["codex"] = True
+        return config
+
+    def _set_oauth_buttons_enabled(self, enabled):
+        """Enable or disable OAuth action buttons."""
+        self.openai_oauth_login_btn.setEnabled(enabled)
+        self.openai_oauth_refresh_btn.setEnabled(enabled)
+        self.openai_oauth_logout_btn.setEnabled(enabled)
+
+    def _login_openai_oauth(self):
+        """Start OpenAI OAuth login."""
+        if self._oauth_worker is not None:
+            return
+        try:
+            config = self._oauth_config()
+        except Exception as exc:
+            QMessageBox.warning(self, "ChatGPT Login", str(exc))
+            return
+
+        self.openai_oauth_status_label.setText("Waiting for browser login...")
+        self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: #1976D2;")
+        self._set_oauth_buttons_enabled(False)
+        self._oauth_worker = OAuthLoginWorker(config, self)
+        self._oauth_worker.auth_url.connect(self._open_oauth_browser)
+        self._oauth_worker.finished.connect(self._on_oauth_worker_finished)
+        self._oauth_worker.start()
+
+    def _refresh_openai_oauth(self):
+        """Refresh the stored OpenAI OAuth token."""
+        if self._oauth_worker is not None:
+            return
+        try:
+            config = self._oauth_config()
+            from ..oauth import load_token_payload
+
+            payload = load_token_payload(self.settings)
+            refresh_token = str(payload.get("refresh_token", "")).strip()
+            if not refresh_token:
+                raise ValueError("No refresh token is stored. Login again.")
+        except Exception as exc:
+            QMessageBox.warning(self, "ChatGPT Login", str(exc))
+            return
+
+        self.openai_oauth_status_label.setText("Refreshing token...")
+        self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: #1976D2;")
+        self._set_oauth_buttons_enabled(False)
+        self._oauth_worker = OAuthRefreshWorker(config, refresh_token, self)
+        self._oauth_worker.finished.connect(self._on_oauth_worker_finished)
+        self._oauth_worker.start()
+
+    def _logout_openai_oauth(self):
+        """Clear stored OpenAI OAuth tokens."""
+        try:
+            clear_token_payload(self.settings)
+        except Exception as exc:
+            QMessageBox.warning(self, "ChatGPT Login", str(exc))
+            return
+        self._refresh_oauth_status()
+        self.iface.messageBar().pushSuccess("GEE Data Catalogs", "ChatGPT logged out.")
+
+    def _open_oauth_browser(self, url):
+        """Open the OAuth authorization URL in the user's browser."""
+        QDesktopServices.openUrl(QUrl(url))
+
+    def _on_oauth_worker_finished(self, result):
+        """Persist OAuth tokens from the login or refresh worker."""
+        self._set_oauth_buttons_enabled(True)
+        self._oauth_worker = None
+        if not result.get("success"):
+            self.openai_oauth_status_label.setText("Login failed")
+            self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: red;")
+            QMessageBox.critical(self, "ChatGPT Login", result.get("error", "Failed"))
+            return
+        try:
+            store_token_payload(self.settings, result["token"])
+            index = self.provider_combo.findText("openai-codex")
+            if index >= 0:
+                self.provider_combo.setCurrentIndex(index)
+                self.settings.setValue(
+                    f"{self.SETTINGS_PREFIX}provider", "openai-codex"
+                )
+                model = self.model_input.text().strip() or DEFAULT_MODELS.get(
+                    "openai-codex", ""
+                )
+                if model:
+                    self.model_input.setText(model)
+                    self.settings.setValue(f"{self.SETTINGS_PREFIX}model", model)
+        except Exception as exc:
+            self.openai_oauth_status_label.setText("Token storage failed")
+            self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: red;")
+            QMessageBox.critical(self, "ChatGPT Login", str(exc))
+            return
+        self._refresh_oauth_status()
+        self.iface.messageBar().pushSuccess("GEE Data Catalogs", "ChatGPT connected.")
+
+    def _refresh_oauth_status(self):
+        """Update the OAuth login status label."""
+        authcfg = self.settings.value(f"{self.SETTINGS_PREFIX}openai_oauth_authcfg", "")
+        expires_at = self.settings.value(
+            f"{self.SETTINGS_PREFIX}openai_oauth_expires_at", "", type=str
+        )
+        if not str(authcfg).strip():
+            self.openai_oauth_status_label.setText("Not logged in")
+            self.openai_oauth_status_label.setStyleSheet(
+                "font-size: 10px; color: gray;"
+            )
+            return
+        if expires_at:
+            try:
+                expiry = time.strftime(
+                    "%Y-%m-%d %H:%M:%S",
+                    time.localtime(float(expires_at)),
+                )
+                text = f"Logged in. Access token expires at {expiry}."
+            except (TypeError, ValueError):
+                text = "Logged in. Access token expiry is unknown."
+        else:
+            text = "Logged in. Access token expiry is unknown."
+        self.openai_oauth_status_label.setText(text)
+        self.openai_oauth_status_label.setStyleSheet("font-size: 10px; color: green;")
+
     def _on_provider_changed(self, provider):
         """Update the model field when the provider changes."""
         self.model_input.setText(DEFAULT_MODELS.get(provider, ""))
+
+    def _credential_value(self, key):
+        """Return ``(value, from_env)`` for a credential field."""
+        saved = self.settings.value(f"{self.SETTINGS_PREFIX}{key}", "", type=str)
+        if str(saved).strip():
+            return str(saved), False
+        fallback = _env_fallback(*ENV_FALLBACKS.get(key, ()))
+        return fallback, bool(fallback)
 
     def _load_settings(self):
         """Load settings from QSettings."""
@@ -452,11 +719,11 @@ class SettingsDockWidget(QDockWidget):
 
         # AI model
         provider = self.settings.value(
-            f"{self.SETTINGS_PREFIX}provider", "openai", type=str
+            f"{self.SETTINGS_PREFIX}provider", DEFAULT_PROVIDER, type=str
         )
         provider_index = self.provider_combo.findText(provider)
         if provider_index < 0:
-            provider_index = self.provider_combo.findText("openai")
+            provider_index = self.provider_combo.findText(DEFAULT_PROVIDER)
         self.provider_combo.setCurrentIndex(
             provider_index if provider_index >= 0 else 0
         )
@@ -469,29 +736,14 @@ class SettingsDockWidget(QDockWidget):
         self.max_tokens_spin.setValue(
             self.settings.value(f"{self.SETTINGS_PREFIX}max_tokens", 4096, type=int)
         )
-        self.openai_key_input.setText(
-            self.settings.value(f"{self.SETTINGS_PREFIX}openai_api_key", "", type=str)
-        )
-        self.anthropic_key_input.setText(
-            self.settings.value(
-                f"{self.SETTINGS_PREFIX}anthropic_api_key", "", type=str
-            )
-        )
-        self.gemini_key_input.setText(
-            self.settings.value(f"{self.SETTINGS_PREFIX}gemini_api_key", "", type=str)
-        )
-        self.aws_region_input.setText(
-            self.settings.value(f"{self.SETTINGS_PREFIX}aws_region", "", type=str)
-        )
-        self.ollama_host_input.setText(
-            self.settings.value(f"{self.SETTINGS_PREFIX}ollama_host", "", type=str)
-        )
-        self.litellm_key_input.setText(
-            self.settings.value(f"{self.SETTINGS_PREFIX}litellm_api_key", "", type=str)
-        )
-        self.litellm_base_url_input.setText(
-            self.settings.value(f"{self.SETTINGS_PREFIX}litellm_base_url", "", type=str)
-        )
+        self._env_sourced_credentials = {}
+        for key, widget in self._credential_inputs:
+            value, from_env = self._credential_value(key)
+            widget.setText(value)
+            if from_env:
+                self._env_sourced_credentials[key] = value
+
+        self._refresh_oauth_status()
 
         self.status_label.setText("Settings loaded")
         self.status_label.setStyleSheet("color: gray; font-size: 10px;")
@@ -563,29 +815,12 @@ class SettingsDockWidget(QDockWidget):
         self.settings.setValue(
             f"{self.SETTINGS_PREFIX}max_tokens", self.max_tokens_spin.value()
         )
-        self.settings.setValue(
-            f"{self.SETTINGS_PREFIX}openai_api_key", self.openai_key_input.text()
-        )
-        self.settings.setValue(
-            f"{self.SETTINGS_PREFIX}anthropic_api_key",
-            self.anthropic_key_input.text(),
-        )
-        self.settings.setValue(
-            f"{self.SETTINGS_PREFIX}gemini_api_key", self.gemini_key_input.text()
-        )
-        self.settings.setValue(
-            f"{self.SETTINGS_PREFIX}aws_region", self.aws_region_input.text()
-        )
-        self.settings.setValue(
-            f"{self.SETTINGS_PREFIX}ollama_host", self.ollama_host_input.text()
-        )
-        self.settings.setValue(
-            f"{self.SETTINGS_PREFIX}litellm_api_key", self.litellm_key_input.text()
-        )
-        self.settings.setValue(
-            f"{self.SETTINGS_PREFIX}litellm_base_url",
-            self.litellm_base_url_input.text(),
-        )
+        for key, widget in self._credential_inputs:
+            current = widget.text()
+            env_value = self._env_sourced_credentials.get(key)
+            if env_value is not None and current == env_value:
+                continue
+            self.settings.setValue(f"{self.SETTINGS_PREFIX}{key}", current)
 
         self.settings.sync()
 
@@ -610,6 +845,12 @@ class SettingsDockWidget(QDockWidget):
         if reply != QMessageBox.StandardButton.Yes:
             return
 
+        try:
+            clear_token_payload(self.settings)
+        except Exception as exc:
+            QMessageBox.warning(self, "ChatGPT Login", str(exc))
+            return
+
         # General
         self.auto_init_check.setChecked(True)
         self.notifications_check.setChecked(True)
@@ -632,8 +873,8 @@ class SettingsDockWidget(QDockWidget):
         self.stretch_type.setCurrentIndex(0)
 
         # AI model
-        self.provider_combo.setCurrentText("openai")
-        self.model_input.setText(DEFAULT_MODELS["openai"])
+        self.provider_combo.setCurrentText(DEFAULT_PROVIDER)
+        self.model_input.setText(DEFAULT_MODELS[DEFAULT_PROVIDER])
         self.fast_check.setChecked(False)
         self.max_tokens_spin.setValue(4096)
         self.openai_key_input.clear()
@@ -643,6 +884,8 @@ class SettingsDockWidget(QDockWidget):
         self.ollama_host_input.clear()
         self.litellm_key_input.clear()
         self.litellm_base_url_input.clear()
+        self._env_sourced_credentials = {}
+        self._refresh_oauth_status()
 
         self.status_label.setText("Defaults restored (not saved)")
         self.status_label.setStyleSheet("color: orange; font-size: 10px;")

--- a/gee_data_catalogs/oauth.py
+++ b/gee_data_catalogs/oauth.py
@@ -1,0 +1,535 @@
+"""OAuth helpers for the GEE Data Catalogs QGIS plugin."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+SETTINGS_PREFIX = "GeeDataCatalogs/"
+OPENAI_CODEX_AUTHORIZATION_URL = "https://auth.openai.com/oauth/authorize"
+# Public OAuth endpoint URL, not a credential.
+OPENAI_CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"  # nosec B105
+OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+OPENAI_CODEX_SCOPE = "openid profile email offline_access"
+OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+OPENAI_CODEX_CALLBACK_PORT = 1455
+OPENAI_CODEX_CALLBACK_PATH = "/auth/callback"
+# OAuth authorize-request flag values below are protocol parameters, not credentials.
+OPENAI_CODEX_AUTH_EXTRA_PARAMS = {  # nosec B105
+    "id_token_add_organizations": "true",
+    "codex_cli_simplified_flow": "true",
+    "originator": "pi",
+}
+AUTHCFG_KEY = "openai_oauth_authcfg"
+EXPIRES_AT_KEY = "openai_oauth_expires_at"
+# QSettings key name, not a credential.
+TOKEN_TYPE_KEY = "openai_oauth_token_type"  # nosec B105
+REFRESH_SKEW_SECONDS = 300
+
+OAUTH_CONFIG_KEYS = (
+    "openai_oauth_authorization_url",
+    "openai_oauth_token_url",
+    "openai_oauth_client_id",
+    "openai_oauth_scope",
+    "openai_oauth_base_url",
+)
+OAUTH_TOKEN_SETTING_KEYS = (
+    AUTHCFG_KEY,
+    EXPIRES_AT_KEY,
+    TOKEN_TYPE_KEY,
+)
+CODEX_DEFAULT_CONFIG = {
+    "authorization_url": OPENAI_CODEX_AUTHORIZATION_URL,
+    "token_url": OPENAI_CODEX_TOKEN_URL,
+    "client_id": OPENAI_CODEX_CLIENT_ID,
+    "scope": OPENAI_CODEX_SCOPE,
+    "base_url": OPENAI_CODEX_BASE_URL,
+}
+
+
+@dataclass
+class OAuthLoopbackFlow:
+    """Pending localhost callback flow."""
+
+    authorization_url: str
+    redirect_uri: str
+    state: str
+    code_verifier: str
+    server: HTTPServer
+    collector: dict[str, Any]
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Return an OAuth PKCE verifier and S256 challenge."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
+
+
+def generate_state() -> str:
+    """Return a cryptographically random OAuth state value."""
+    return secrets.token_urlsafe(32)
+
+
+def token_expires_soon(
+    expires_at: float | int | str | None,
+    *,
+    now: float | None = None,
+    skew_seconds: int = REFRESH_SKEW_SECONDS,
+) -> bool:
+    """Return True when a token is missing or near expiry."""
+    if not expires_at:
+        return True
+    try:
+        expiry = float(expires_at)
+    except (TypeError, ValueError):
+        return True
+    current = time.time() if now is None else now
+    return expiry <= current + skew_seconds
+
+
+def decode_jwt_payload(token: str) -> dict[str, Any]:
+    """Decode an unsigned JWT payload for local claim extraction."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    try:
+        data = base64.urlsafe_b64decode((payload + padding).encode("ascii"))
+        decoded = json.loads(data.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def extract_chatgpt_account_id(token_payload: dict[str, Any]) -> str:
+    """Extract the ChatGPT account id from OAuth token claims when present."""
+    for token_key in ("access_token", "id_token"):
+        claims = decode_jwt_payload(str(token_payload.get(token_key, "")))
+        direct = claims.get("https://api.openai.com/auth.chatgpt_account_id")
+        if isinstance(direct, str) and direct.strip():
+            return direct.strip()
+        auth_claim = claims.get("https://api.openai.com/auth")
+        if isinstance(auth_claim, dict):
+            nested = auth_claim.get("chatgpt_account_id")
+            if isinstance(nested, str) and nested.strip():
+                return nested.strip()
+        for fallback_key in ("chatgpt_account_id", "account_id"):
+            fallback = claims.get(fallback_key)
+            if isinstance(fallback, str) and fallback.strip():
+                return fallback.strip()
+    return ""
+
+
+def build_authorization_url(
+    authorization_url: str,
+    *,
+    client_id: str,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+    scope: str = "",
+    extra_params: dict[str, str] | None = None,
+) -> str:
+    """Build an OAuth authorization-code URL with PKCE parameters."""
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    if scope:
+        params["scope"] = scope
+    if extra_params:
+        params.update(extra_params)
+    separator = "&" if urllib.parse.urlparse(authorization_url).query else "?"
+    return authorization_url + separator + urllib.parse.urlencode(params)
+
+
+def extract_authorization_code(callback_url: str, expected_state: str) -> str:
+    """Validate a callback URL and return its authorization code."""
+    parsed = urllib.parse.urlparse(callback_url)
+    query = urllib.parse.parse_qs(parsed.query)
+    state = query.get("state", [""])[0]
+    if state != expected_state:
+        raise ValueError("OAuth callback state did not match the login request.")
+    error = query.get("error", [""])[0]
+    if error:
+        description = query.get("error_description", [""])[0]
+        raise ValueError(description or f"OAuth authorization failed: {error}")
+    code = query.get("code", [""])[0]
+    if not code:
+        raise ValueError("OAuth callback did not include an authorization code.")
+    return code
+
+
+class _OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """Capture a single OAuth callback."""
+
+    def do_GET(self):  # noqa: N802
+        """Handle the OAuth redirect."""
+        collector = self.server.collector  # type: ignore[attr-defined]
+        collector["url"] = f"http://127.0.0.1:{self.server.server_port}{self.path}"
+        body = (
+            "<html><body><h3>GEE Data Catalogs login complete</h3>"
+            "<p>You can close this browser tab and return to QGIS.</p>"
+            "</body></html>"
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):  # noqa: A002
+        """Suppress callback server logging in QGIS."""
+        return
+
+
+def start_loopback_flow(
+    authorization_url: str,
+    *,
+    client_id: str,
+    scope: str = "",
+    bind_host: str = "127.0.0.1",
+    redirect_host: str = "127.0.0.1",
+    port: int = 0,
+    callback_path: str = "/callback",
+    extra_params: dict[str, str] | None = None,
+    fallback_port: bool = True,
+) -> OAuthLoopbackFlow:
+    """Start a localhost callback server and return the pending OAuth flow."""
+    verifier, challenge = generate_pkce_pair()
+    state = generate_state()
+    collector: dict[str, Any] = {}
+    try:
+        server = HTTPServer((bind_host, port), _OAuthCallbackHandler)
+    except OSError as exc:
+        if port == 0 or not fallback_port:
+            if port:
+                raise RuntimeError(
+                    f"OAuth callback port {port} is not available."
+                ) from exc
+            raise
+        server = HTTPServer((bind_host, 0), _OAuthCallbackHandler)
+    server.timeout = 1
+    server.collector = collector  # type: ignore[attr-defined]
+    if not callback_path.startswith("/"):
+        callback_path = "/" + callback_path
+    redirect_uri = f"http://{redirect_host}:{server.server_port}{callback_path}"
+    url = build_authorization_url(
+        authorization_url,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        code_challenge=challenge,
+        state=state,
+        scope=scope,
+        extra_params=extra_params,
+    )
+    return OAuthLoopbackFlow(url, redirect_uri, state, verifier, server, collector)
+
+
+def complete_loopback_flow(
+    flow: OAuthLoopbackFlow,
+    *,
+    token_url: str,
+    client_id: str,
+    timeout_seconds: int = 180,
+) -> dict[str, Any]:
+    """Wait for the browser callback and exchange the code for tokens."""
+    deadline = time.time() + timeout_seconds
+    try:
+        while time.time() < deadline and "url" not in flow.collector:
+            flow.server.handle_request()
+        if "url" not in flow.collector:
+            raise TimeoutError("Timed out waiting for the OAuth browser callback.")
+        code = extract_authorization_code(flow.collector["url"], flow.state)
+        return exchange_authorization_code(
+            token_url,
+            client_id=client_id,
+            code=code,
+            redirect_uri=flow.redirect_uri,
+            code_verifier=flow.code_verifier,
+        )
+    finally:
+        flow.server.server_close()
+
+
+def _post_form(url: str, data: dict[str, str]) -> dict[str, Any]:
+    """POST URL-encoded form data and return decoded JSON."""
+    encoded = urllib.parse.urlencode(data).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=encoded,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # nosec B310
+            payload = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"OAuth token request failed: {exc.code} {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"OAuth token request failed: {exc}") from exc
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("OAuth token endpoint did not return JSON.") from exc
+
+
+def _normalize_token_response(response: dict[str, Any]) -> dict[str, Any]:
+    """Validate and add an absolute expiry timestamp to a token response."""
+    access_token = str(response.get("access_token", "")).strip()
+    if not access_token:
+        raise RuntimeError("OAuth token endpoint did not return an access token.")
+    normalized = dict(response)
+    try:
+        expires_in = int(normalized.get("expires_in", 3600))
+    except (TypeError, ValueError):
+        expires_in = 3600
+    normalized["expires_at"] = int(time.time()) + max(expires_in, 0)
+    normalized["token_type"] = str(normalized.get("token_type") or "Bearer")
+    account_id = extract_chatgpt_account_id(normalized)
+    if account_id:
+        normalized["account_id"] = account_id
+    return normalized
+
+
+def exchange_authorization_code(
+    token_url: str,
+    *,
+    client_id: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> dict[str, Any]:
+    """Exchange an authorization code for an OAuth token payload."""
+    response = _post_form(
+        token_url,
+        {
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        },
+    )
+    return _normalize_token_response(response)
+
+
+def refresh_oauth_token(
+    token_url: str,
+    *,
+    client_id: str,
+    refresh_token: str,
+    scope: str = "",
+) -> dict[str, Any]:
+    """Refresh an OAuth access token."""
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+        "refresh_token": refresh_token,
+    }
+    if scope:
+        data["scope"] = scope
+    response = _post_form(token_url, data)
+    normalized = _normalize_token_response(response)
+    if "refresh_token" not in normalized:
+        normalized["refresh_token"] = refresh_token
+    return normalized
+
+
+def _qgis_auth_manager():
+    """Return the QGIS auth manager or raise a clear setup error."""
+    try:
+        from qgis.core import QgsApplication
+    except Exception as exc:
+        raise RuntimeError(
+            "QGIS Auth Manager is required for OAuth token storage."
+        ) from exc
+    manager = QgsApplication.authManager()
+    if manager is None:
+        raise RuntimeError("QGIS Auth Manager is not available.")
+    return manager
+
+
+def _store_secret_payload(payload: dict[str, Any], existing_authcfg: str = "") -> str:
+    """Store OAuth tokens in QGIS Auth Manager and return the auth config id."""
+    try:
+        from qgis.core import QgsAuthMethodConfig
+    except Exception as exc:
+        raise RuntimeError(
+            "QGIS Auth Manager is required for OAuth token storage."
+        ) from exc
+
+    manager = _qgis_auth_manager()
+    config = QgsAuthMethodConfig()
+    if existing_authcfg:
+        try:
+            manager.loadAuthenticationConfig(existing_authcfg, config, True)
+        except TypeError:
+            manager.loadAuthenticationConfig(existing_authcfg, config)
+    config.setName("GEE Data Catalogs ChatGPT Login")
+    config.setMethod("Basic")
+    config.setConfig("username", "openai-codex")
+    config.setConfig("password", json.dumps(payload))
+    if existing_authcfg:
+        ok = manager.updateAuthenticationConfig(config)
+        authcfg = existing_authcfg
+    else:
+        ok = manager.storeAuthenticationConfig(config)
+        authcfg = config.id()
+    if not ok:
+        raise RuntimeError("Failed to store OAuth tokens in QGIS Auth Manager.")
+    return authcfg
+
+
+def _load_secret_payload(authcfg: str) -> dict[str, Any]:
+    """Load OAuth tokens from QGIS Auth Manager."""
+    try:
+        from qgis.core import QgsAuthMethodConfig
+    except Exception as exc:
+        raise RuntimeError(
+            "QGIS Auth Manager is required for OAuth token storage."
+        ) from exc
+
+    manager = _qgis_auth_manager()
+    config = QgsAuthMethodConfig()
+    try:
+        ok = manager.loadAuthenticationConfig(authcfg, config, True)
+    except TypeError:
+        ok = manager.loadAuthenticationConfig(authcfg, config)
+    if not ok:
+        raise RuntimeError("OpenAI OAuth tokens were not found in QGIS Auth Manager.")
+    raw = config.config("password")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Stored OpenAI OAuth token payload is invalid.") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Stored OpenAI OAuth token payload is invalid.")
+    return payload
+
+
+def _remove_secret_payload(authcfg: str) -> None:
+    """Remove a QGIS Auth Manager token payload."""
+    if not authcfg:
+        return
+    manager = _qgis_auth_manager()
+    manager.removeAuthenticationConfig(authcfg)
+
+
+def store_token_payload(
+    settings,
+    token_payload: dict[str, Any],
+    *,
+    prefix: str = SETTINGS_PREFIX,
+) -> str:
+    """Store OAuth tokens and persist only the auth reference in QSettings."""
+    existing_authcfg = settings.value(f"{prefix}{AUTHCFG_KEY}", "", type=str)
+    authcfg = _store_secret_payload(token_payload, str(existing_authcfg or ""))
+    settings.setValue(f"{prefix}{AUTHCFG_KEY}", authcfg)
+    settings.setValue(
+        f"{prefix}{EXPIRES_AT_KEY}", str(token_payload.get("expires_at", ""))
+    )
+    settings.setValue(
+        f"{prefix}{TOKEN_TYPE_KEY}", str(token_payload.get("token_type", "Bearer"))
+    )
+    return authcfg
+
+
+def load_token_payload(settings, *, prefix: str = SETTINGS_PREFIX) -> dict[str, Any]:
+    """Load the OAuth token payload referenced by QSettings."""
+    authcfg = settings.value(f"{prefix}{AUTHCFG_KEY}", "", type=str)
+    if not str(authcfg).strip():
+        raise RuntimeError("OpenAI OAuth is not logged in.")
+    return _load_secret_payload(str(authcfg))
+
+
+def clear_token_payload(settings, *, prefix: str = SETTINGS_PREFIX) -> None:
+    """Remove OAuth tokens and their QSettings references."""
+    authcfg = settings.value(f"{prefix}{AUTHCFG_KEY}", "", type=str)
+    if str(authcfg).strip():
+        _remove_secret_payload(str(authcfg))
+    for key in OAUTH_TOKEN_SETTING_KEYS:
+        settings.remove(f"{prefix}{key}")
+
+
+def ensure_openai_oauth_environment(
+    settings,
+    *,
+    prefix: str = SETTINGS_PREFIX,
+    codex: bool = True,
+) -> None:
+    """Refresh tokens if needed and export env vars for GeoAgent model creation."""
+    base_url = settings.value(f"{prefix}openai_oauth_base_url", "", type=str).strip()
+    if not base_url:
+        base_url = os.environ.get("OPENAI_CODEX_BASE_URL", "").strip()
+    if not base_url:
+        base_url = OPENAI_CODEX_BASE_URL
+    if not base_url:
+        raise RuntimeError("OpenAI Codex base URL is not configured.")
+
+    authcfg = settings.value(f"{prefix}{AUTHCFG_KEY}", "", type=str)
+    if not str(authcfg).strip():
+        access_token = os.environ.get("OPENAI_CODEX_ACCESS_TOKEN", "").strip()
+        if access_token:
+            os.environ["OPENAI_CODEX_ACCESS_TOKEN"] = access_token
+            os.environ["OPENAI_CODEX_BASE_URL"] = base_url
+            account_id = os.environ.get("OPENAI_CODEX_ACCOUNT_ID", "").strip()
+            if not account_id:
+                account_id = extract_chatgpt_account_id({"access_token": access_token})
+            if account_id:
+                os.environ["OPENAI_CODEX_ACCOUNT_ID"] = account_id
+            return
+
+    payload = load_token_payload(settings, prefix=prefix)
+    if token_expires_soon(payload.get("expires_at")):
+        refresh_token = str(payload.get("refresh_token", "")).strip()
+        if not refresh_token:
+            raise RuntimeError(
+                "OpenAI OAuth token expired and no refresh token is stored."
+            )
+        token_url = settings.value(
+            f"{prefix}openai_oauth_token_url", "", type=str
+        ).strip()
+        client_id = settings.value(
+            f"{prefix}openai_oauth_client_id", "", type=str
+        ).strip()
+        scope = settings.value(f"{prefix}openai_oauth_scope", "", type=str).strip()
+        token_url = token_url or OPENAI_CODEX_TOKEN_URL
+        client_id = client_id or OPENAI_CODEX_CLIENT_ID
+        scope = scope or OPENAI_CODEX_SCOPE
+        if not token_url or not client_id:
+            raise RuntimeError("OpenAI OAuth token URL and client ID are required.")
+        payload = refresh_oauth_token(
+            token_url,
+            client_id=client_id,
+            refresh_token=refresh_token,
+            scope=scope,
+        )
+        store_token_payload(settings, payload, prefix=prefix)
+
+    access_token = str(payload.get("access_token", "")).strip()
+    if not access_token:
+        raise RuntimeError("Stored OpenAI OAuth token payload has no access token.")
+    os.environ["OPENAI_CODEX_ACCESS_TOKEN"] = access_token
+    os.environ["OPENAI_CODEX_BASE_URL"] = base_url
+    account_id = str(payload.get("account_id", "")).strip()
+    if account_id:
+        os.environ["OPENAI_CODEX_ACCOUNT_ID"] = account_id

--- a/tests/test_ai_provider_config.py
+++ b/tests/test_ai_provider_config.py
@@ -37,6 +37,37 @@ def test_conversation_markdown_includes_full_history():
     )
 
 
+def test_extract_earth_engine_snippet_from_tool_metadata():
+    snippet = "import ee\nimage = ee.Image('NASA/NASADEM_HGT/001')"
+    tool_calls = [
+        {
+            "name": "load_gee_dataset",
+            "result": {
+                "content": [
+                    {
+                        "text": repr(
+                            {
+                                "success": True,
+                                "earth_engine_python_snippet": snippet,
+                            }
+                        )
+                    }
+                ]
+            },
+        }
+    ]
+
+    assert chat_dock._extract_earth_engine_snippets(tool_calls) == [snippet]
+
+
+def test_extract_python_code_block_fallback():
+    answer = "Layer code:\n```python\nimport ee\nimage = ee.Image('A/B')\n```"
+
+    assert chat_dock._extract_python_code_blocks(answer) == [
+        "import ee\nimage = ee.Image('A/B')"
+    ]
+
+
 def test_credential_value_prefers_saved_setting_over_environment(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
     harness = _CredentialHarness({"GeeDataCatalogs/openai_api_key": "saved-key"})

--- a/tests/test_ai_provider_config.py
+++ b/tests/test_ai_provider_config.py
@@ -1,0 +1,63 @@
+from gee_data_catalogs.dialogs import chat_dock, settings_dock
+
+
+class _FakeSettings:
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def value(self, key, default="", type=str):  # noqa: A002
+        return self.values.get(key, default)
+
+
+class _CredentialHarness:
+    SETTINGS_PREFIX = "GeeDataCatalogs/"
+
+    def __init__(self, values=None):
+        self.settings = _FakeSettings(values)
+
+
+def test_openai_codex_is_default_provider():
+    assert chat_dock.DEFAULT_PROVIDER == "openai-codex"
+    assert "openai-codex" in chat_dock.PROVIDERS
+    assert chat_dock.DEFAULT_MODELS["openai-codex"] == "gpt-5.5"
+    assert settings_dock.DEFAULT_PROVIDER == "openai-codex"
+
+
+def test_conversation_markdown_includes_full_history():
+    markdown = chat_dock._conversation_markdown(
+        [
+            {"sender": "You", "body": "Find Sentinel-2 data"},
+            {"sender": "GeoAgent", "body": "Use `COPERNICUS/S2_SR_HARMONIZED`."},
+        ]
+    )
+
+    assert markdown == (
+        "## You\n\nFind Sentinel-2 data\n\n"
+        "## GeoAgent\n\nUse `COPERNICUS/S2_SR_HARMONIZED`."
+    )
+
+
+def test_credential_value_prefers_saved_setting_over_environment(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    harness = _CredentialHarness({"GeeDataCatalogs/openai_api_key": "saved-key"})
+
+    assert settings_dock.SettingsDockWidget._credential_value(
+        harness, "openai_api_key"
+    ) == ("saved-key", False)
+
+
+def test_credential_value_falls_back_to_environment(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    harness = _CredentialHarness()
+
+    assert settings_dock.SettingsDockWidget._credential_value(
+        harness, "openai_api_key"
+    ) == ("env-key", True)
+
+
+def test_apply_environment_keeps_existing_env_when_setting_empty(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "existing-key")
+
+    chat_dock._apply_environment_from_settings(_FakeSettings())
+
+    assert chat_dock.os.environ["OPENAI_API_KEY"] == "existing-key"

--- a/tests/test_ee_layer_add.py
+++ b/tests/test_ee_layer_add.py
@@ -1,0 +1,119 @@
+import sys
+import types
+
+from gee_data_catalogs.core import ee_utils
+
+
+def test_add_ee_layer_falls_back_when_qgis_geemap_returns_invalid(monkeypatch):
+    created_layers = []
+    added_layers = []
+    inserted_layers = []
+    removed_layers = []
+
+    class _FakeLayer:
+        def __init__(self, uri="", name="", provider="", valid=True):
+            self.uri = uri
+            self._name = name
+            self.provider = provider
+            self._valid = valid
+            self.custom_properties = {}
+
+        def isValid(self):
+            return self._valid
+
+        def id(self):
+            return self._name or "layer-id"
+
+        def name(self):
+            return self._name
+
+        def renderer(self):
+            return None
+
+        def setCustomProperty(self, key, value):
+            self.custom_properties[key] = value
+
+    class _QgsRasterLayer(_FakeLayer):
+        def __init__(self, uri="", name="", provider=""):
+            super().__init__(uri, name, provider, valid=True)
+            created_layers.append(self)
+
+    class _InvalidGeemapLayer(_FakeLayer):
+        def __init__(self):
+            super().__init__(valid=False)
+
+    class _LayerTreeRoot:
+        def insertLayer(self, index, layer):
+            inserted_layers.append((index, layer))
+
+        def findLayer(self, layer_id):
+            return None
+
+    class _Project:
+        def mapLayersByName(self, name):
+            return []
+
+        def removeMapLayer(self, layer_id):
+            removed_layers.append(layer_id)
+
+        def addMapLayer(self, layer, add_to_legend):
+            added_layers.append((layer, add_to_legend))
+
+        def layerTreeRoot(self):
+            return _LayerTreeRoot()
+
+    class _QgsProject:
+        @staticmethod
+        def instance():
+            return _Project()
+
+    class _FakeImage:
+        def getMapId(self, vis_params):
+            return {
+                "tile_fetcher": types.SimpleNamespace(
+                    url_format=("https://example.com/{z}/{x}/{y}?token=abc&expires=123")
+                )
+            }
+
+        def get(self, key):
+            raise RuntimeError("no asset id")
+
+    class _FakeImageCollection:
+        pass
+
+    class _FakeFeatureCollection:
+        pass
+
+    class _FakeMap:
+        def add_layer(self, ee_object, vis_params, name, shown, opacity):
+            return _InvalidGeemapLayer()
+
+    ee_module = types.SimpleNamespace(
+        Image=_FakeImage,
+        ImageCollection=_FakeImageCollection,
+        FeatureCollection=_FakeFeatureCollection,
+        serializer=types.SimpleNamespace(toJSON=lambda obj: "{}"),
+    )
+    qgis_geemap_module = types.ModuleType("qgis_geemap.core.qgis_map")
+    qgis_geemap_module.Map = _FakeMap
+
+    monkeypatch.setattr(ee_utils, "ee", ee_module)
+    monkeypatch.setattr(ee_utils, "QgsRasterLayer", _QgsRasterLayer)
+    monkeypatch.setattr(ee_utils, "QgsProject", _QgsProject)
+    monkeypatch.setitem(sys.modules, "qgis_geemap", types.ModuleType("qgis_geemap"))
+    monkeypatch.setitem(
+        sys.modules, "qgis_geemap.core", types.ModuleType("qgis_geemap.core")
+    )
+    monkeypatch.setitem(sys.modules, "qgis_geemap.core.qgis_map", qgis_geemap_module)
+
+    layer = ee_utils.add_ee_layer(_FakeImage(), {"min": 0, "max": 1}, "DSWx")
+
+    assert layer is created_layers[0]
+    expected_uri = (
+        "type=xyz&url=https://example.com/{z}/{x}/{y}"
+        "%3Ftoken%3Dabc%26expires%3D123&zmax=24&zmin=0"
+    )
+    assert layer.uri == expected_uri
+    assert added_layers == [(layer, False)]
+    assert inserted_layers == [(0, layer)]
+    assert removed_layers == []


### PR DESCRIPTION
## Summary
- Adds an OpenAI Codex OAuth flow (loopback PKCE, tokens stored in QGIS Auth Manager) and a "Login with ChatGPT" UI in the settings dock, with `openai-codex` becoming the default AI provider.
- Makes `add_ee_layer` fall back to a direct XYZ raster layer when `qgis_geemap` returns an invalid layer, and URL-encodes the nested tile URL so query parameters survive.
- Adds environment-variable fallbacks for stored credentials, full-transcript Markdown copy in the chat dock, and tests covering both the EE fallback and the new provider/credential behavior.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] In QGIS, open Settings, click "Login with ChatGPT", complete the browser flow, and confirm the status label shows the access-token expiry.
- [ ] Send a chat prompt with provider `openai-codex` and confirm a response.
- [ ] Add an EE layer when `qgis_geemap` is unavailable or returns an invalid layer, and confirm the fallback XYZ raster renders.