### PR TITLE
feat(ai): prompt before running GeoAgent tools, add auto-approve toggle

### DIFF
--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -8,6 +8,7 @@ import re
 import time
 import traceback
 
+from qgis.core import Qgis, QgsMessageLog
 from qgis.PyQt.QtCore import QSettings, QThread, QTimer, Qt, pyqtSignal
 from qgis.PyQt.QtGui import QGuiApplication, QTextCursor
 from qgis.PyQt.QtWidgets import (
@@ -40,13 +41,13 @@ DEFAULT_MODELS = {
     "litellm": "openai/gpt-5.5",
 }
 PROVIDERS = [
+    "anthropic",
     "bedrock",
+    "gemini",
+    "litellm",
+    "ollama",
     "openai",
     "openai-codex",
-    "anthropic",
-    "gemini",
-    "ollama",
-    "litellm",
 ]
 MAX_CONTEXT_MESSAGES = 12
 MAX_CONTEXT_CHARS = 12000
@@ -286,7 +287,16 @@ class ChatWorker(QThread):
     finished = pyqtSignal(dict)
 
     def __init__(
-        self, iface, plugin, prompt, provider, model_id, fast, max_tokens, parent=None
+        self,
+        iface,
+        plugin,
+        prompt,
+        provider,
+        model_id,
+        fast,
+        max_tokens,
+        auto_approve_tools=False,
+        parent=None,
     ):
         super().__init__(parent)
         self.iface = iface
@@ -296,10 +306,48 @@ class ChatWorker(QThread):
         self.model_id = model_id or None
         self.fast = fast
         self.max_tokens = max_tokens
+        self.auto_approve_tools = bool(auto_approve_tools)
 
     def _confirm_tool(self, request):
-        """Allow confirmation-required tools to run without a modal prompt."""
-        return True
+        """Ask the QGIS user before running confirmation-required tools."""
+        if self.auto_approve_tools:
+            return True
+
+        from geoagent.tools._qt_marshal import run_on_qt_gui_thread
+
+        def _ask():
+            parent = None
+            try:
+                parent = self.iface.mainWindow()
+            except Exception as exc:
+                QgsMessageLog.logMessage(
+                    f"Could not resolve QGIS main window for confirmation dialog: {exc}",
+                    "GEE Data Catalogs",
+                    Qgis.Warning,
+                )
+
+            arg_lines = []
+            for key, value in request.args.items():
+                text = str(value)
+                if len(text) > 160:
+                    text = text[:157] + "..."
+                arg_lines.append(f"{key}: {text}")
+
+            details = "\n".join(arg_lines) if arg_lines else "No arguments"
+            message = (
+                f"GeoAgent wants to run:\n\n{request.tool_name}\n\n"
+                f"{details}\n\nAllow this action?"
+            )
+            reply = QMessageBox.question(
+                parent,
+                "Confirm GeoAgent Tool",
+                message,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            return reply == QMessageBox.StandardButton.Yes
+
+        return bool(run_on_qt_gui_thread(_ask))
 
     def run(self):
         """Create a GeoAgent GEE Data Catalogs agent and execute one chat turn."""
@@ -430,7 +478,15 @@ class ChatPanelWidget(QWidget):
         model_layout.addRow("Model:", self.model_input)
 
         self.fast_check = QCheckBox("Fast mode")
-        model_layout.addRow("", self.fast_check)
+        self.auto_approve_tools_check = QCheckBox("Auto approve running tools")
+        self.auto_approve_tools_check.setToolTip(
+            "Run confirmation-required tools without prompting for this session."
+        )
+        mode_layout = QHBoxLayout()
+        mode_layout.addWidget(self.fast_check)
+        mode_layout.addWidget(self.auto_approve_tools_check)
+        mode_layout.addStretch(1)
+        model_layout.addRow("", mode_layout)
         layout.addWidget(model_group)
 
         self.sample_combo = QComboBox()
@@ -505,15 +561,22 @@ class ChatPanelWidget(QWidget):
             model = DEFAULT_MODELS.get(self.provider_combo.currentText(), "")
         self.model_input.setText(model)
         self.fast_check.setChecked(_setting(self.settings, "fast_mode", False, bool))
+        self.auto_approve_tools_check.setChecked(
+            _setting(self.settings, "auto_approve_tools", False, bool)
+        )
 
     def _save_model_settings(self):
-        """Persist the selected provider, model, and fast-mode setting."""
+        """Persist the selected provider, model, and mode settings."""
         self.settings.setValue(
             f"{SETTINGS_PREFIX}provider", self.provider_combo.currentText()
         )
         self.settings.setValue(f"{SETTINGS_PREFIX}model", self.model_input.text())
         self.settings.setValue(
             f"{SETTINGS_PREFIX}fast_mode", self.fast_check.isChecked()
+        )
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}auto_approve_tools",
+            self.auto_approve_tools_check.isChecked(),
         )
 
     def _on_provider_changed(self, provider):
@@ -570,6 +633,7 @@ class ChatPanelWidget(QWidget):
         if model_id and not self.model_input.text().strip():
             self.model_input.setText(model_id)
         fast = self.fast_check.isChecked()
+        auto_approve_tools = self.auto_approve_tools_check.isChecked()
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
         prompt_with_context = self._build_prompt_with_context(prompt)
 
@@ -589,6 +653,7 @@ class ChatPanelWidget(QWidget):
             model_id,
             fast,
             max_tokens,
+            auto_approve_tools,
             self,
         )
         self._worker.finished.connect(self._on_worker_finished)

--- a/tests/test_ai_provider_config.py
+++ b/tests/test_ai_provider_config.py
@@ -1,3 +1,6 @@
+import sys
+import types
+
 from gee_data_catalogs.dialogs import chat_dock, settings_dock
 
 
@@ -92,3 +95,47 @@ def test_apply_environment_keeps_existing_env_when_setting_empty(monkeypatch):
     chat_dock._apply_environment_from_settings(_FakeSettings())
 
     assert chat_dock.os.environ["OPENAI_API_KEY"] == "existing-key"
+
+
+def test_confirm_tool_auto_approve_bypasses_confirmation(monkeypatch):
+    class _MessageBox:
+        @staticmethod
+        def question(*_args, **_kwargs):
+            raise AssertionError("confirmation dialog should not open")
+
+    monkeypatch.setattr(chat_dock, "QMessageBox", _MessageBox)
+    worker = chat_dock.ChatWorker(
+        None, None, "prompt", "openai", "gpt-5.5", False, 4096, True
+    )
+
+    assert worker._confirm_tool(types.SimpleNamespace(args={}, tool_name="tool"))
+
+
+def test_confirm_tool_uses_confirmation_when_auto_approve_is_off(monkeypatch):
+    qt_marshal = types.ModuleType("geoagent.tools._qt_marshal")
+    qt_marshal.run_on_qt_gui_thread = lambda callback: callback()
+    monkeypatch.setitem(sys.modules, "geoagent", types.ModuleType("geoagent"))
+    monkeypatch.setitem(
+        sys.modules, "geoagent.tools", types.ModuleType("geoagent.tools")
+    )
+    monkeypatch.setitem(sys.modules, "geoagent.tools._qt_marshal", qt_marshal)
+
+    class _StandardButton:
+        Yes = 1
+        No = 2
+
+    class _MessageBox:
+        StandardButton = _StandardButton
+
+        @staticmethod
+        def question(*_args, **_kwargs):
+            return _StandardButton.No
+
+    monkeypatch.setattr(chat_dock, "QMessageBox", _MessageBox)
+    iface = types.SimpleNamespace(mainWindow=lambda: None)
+    worker = chat_dock.ChatWorker(
+        iface, None, "prompt", "openai", "gpt-5.5", False, 4096, False
+    )
+    request = types.SimpleNamespace(args={"asset_id": "LANDSAT/LC09"}, tool_name="load")
+
+    assert not worker._confirm_tool(request)


### PR DESCRIPTION
## Summary
- Replace the silent always-approve behavior in the GeoAgent chat dock with a Yes/No confirmation dialog that previews the tool name and arguments before execution.
- Marshal the dialog onto the Qt GUI thread so it works safely from the worker thread, and surface a session checkbox plus persisted `auto_approve_tools` setting for users who want to skip prompts.
- Sort the provider list alphabetically for a more predictable picker.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest tests/test_ai_provider_config.py`
- [ ] Manual: trigger a confirmation-required tool with auto-approve off (expect dialog) and on (expect no dialog).