### PR TITLE
fix(security): suppress detect-secrets false positives blocking plugin upload

### DIFF
--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -71,12 +71,12 @@ def _setting(settings, key, default="", value_type=str):
 def _apply_environment_from_settings(settings):
     """Apply provider credentials from QSettings to the current QGIS process."""
     env_map = {
-        "openai_api_key": "OPENAI_API_KEY",
-        "anthropic_api_key": "ANTHROPIC_API_KEY",
+        "openai_api_key": "OPENAI_API_KEY",  # pragma: allowlist secret
+        "anthropic_api_key": "ANTHROPIC_API_KEY",  # pragma: allowlist secret
         "gemini_api_key": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
         "aws_region": "AWS_REGION",
         "ollama_host": "OLLAMA_HOST",
-        "litellm_api_key": "LITELLM_API_KEY",
+        "litellm_api_key": "LITELLM_API_KEY",  # pragma: allowlist secret
         "litellm_base_url": "LITELLM_BASE_URL",
     }
     for key, env_names in env_map.items():


### PR DESCRIPTION
## Summary
- The plugins.qgis.org upload scanner blocked the plugin with 3 `detect-secrets` "Secret Keyword" findings in [gee_data_catalogs/dialogs/chat_dock.py](gee_data_catalogs/dialogs/chat_dock.py) at lines 74, 75, and 79.
- The flagged values are environment variable names (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `LITELLM_API_KEY`), not actual credentials. They're the right-hand side of the `_apply_environment_from_settings` lookup table that maps QSettings keys to env var names.
- Annotated each flagged line with the standard `# pragma: allowlist secret` inline directive so detect-secrets ignores the false positive while leaving the code unchanged. Bandit was already clean.

## Test plan
- [x] `detect-secrets scan gee_data_catalogs` reports 0 findings
- [x] `bandit -r gee_data_catalogs` reports 0 issues
- [x] `pre-commit run --all-files` passes
- [ ] Re-upload plugin to plugins.qgis.org and confirm the Secrets Detection scan passes