### PR TITLE
feat(ai): quieter deps, EE timing/cache, per-step chat timing

### DIFF
--- a/gee_data_catalogs/core/ee_utils.py
+++ b/gee_data_catalogs/core/ee_utils.py
@@ -6,6 +6,7 @@ This module provides utility functions for working with Earth Engine in QGIS.
 
 import json
 import os
+import time
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -26,6 +27,84 @@ _ee_initialized = False
 
 # Global registry to track EE layers for Inspector
 _ee_layer_registry = {}
+
+# Identifier the earthengine-api sends to Earth Engine on every API call
+# (getMapId, getInfo, etc.). The official QGIS GEE plugin does the same so EE
+# can attribute traffic and apply the right per-client quotas. This does not
+# affect tile fetches (those go through QGIS's network manager), only the
+# Python-side EE API calls.
+_EE_USER_AGENT = "qgis-gee-data-catalogs-plugin/0.11.0"
+_ee_user_agent_set = False
+
+
+def _set_ee_user_agent_once() -> None:
+    """Set a stable User-Agent for ee.data API calls (idempotent)."""
+    global _ee_user_agent_set
+    if _ee_user_agent_set or ee is None:
+        return
+    try:
+        if ee.data.getUserAgent() != _EE_USER_AGENT:
+            ee.data.setUserAgent(_EE_USER_AGENT)
+    except Exception:  # nosec B110 - best-effort, never fail init on this
+        return
+    _ee_user_agent_set = True
+
+
+# Cache of (asset_repr, hashable_vis_params) -> tile_url. Populated after a
+# successful getMapId() call so repeated adds of the same dataset (very common
+# when iterating in the AI Assistant) skip the network round-trip. Cleared
+# whenever Earth Engine is re-initialized to avoid stale URLs after re-auth.
+_tile_url_cache: Dict[tuple, str] = {}
+_TILE_CACHE_CAP = 64
+
+
+def _hashable_vis_params(vis_params: Dict) -> tuple:
+    """Return a hashable representation of vis_params for use as a cache key.
+
+    Values that are lists (e.g. ``palette``, ``bands``) are converted to
+    tuples so the resulting key is hashable. Items are sorted by key so two
+    dicts with the same contents produce the same key regardless of insertion
+    order.
+
+    Args:
+        vis_params: Visualization parameters dict.
+
+    Returns:
+        A tuple of (key, value) pairs suitable for use in a dict key.
+    """
+    items = []
+    for key, value in sorted(vis_params.items()):
+        if isinstance(value, list):
+            value = tuple(value)
+        items.append((key, value))
+    return tuple(items)
+
+
+def _tile_cache_key(ee_object: Any, vis_params: Dict) -> Optional[tuple]:
+    """Build a cache key for an EE object + vis_params combination.
+
+    Uses ``ee_object.serialize()`` when available (every ``ComputedObject``
+    has it) so the key reflects the full computation graph, not just the
+    Python object identity. Returns ``None`` if a stable key cannot be built,
+    in which case the caller should bypass the cache.
+
+    Args:
+        ee_object: An Earth Engine object.
+        vis_params: Visualization parameters dict.
+
+    Returns:
+        A hashable tuple key, or None if the object cannot be serialized.
+    """
+    try:
+        asset_repr = ee_object.serialize()
+    except Exception:  # nosec B110 - fall back to bypassing the cache
+        return None
+    return (asset_repr, _hashable_vis_params(vis_params))
+
+
+def _clear_tile_url_cache() -> None:
+    """Drop all cached tile URLs. Called after a successful EE re-init."""
+    _tile_url_cache.clear()
 
 
 def _xyz_uri_from_tile_url(tile_url: str) -> str:
@@ -84,6 +163,8 @@ def initialize_ee(project: str = None, credentials: Any = None) -> bool:
             "The 'ee' module is not installed. Please install earthengine-api."
         )
 
+    _set_ee_user_agent_once()
+
     if project is None or project == "":
         project = os.environ.get("EE_PROJECT_ID", None)
 
@@ -126,6 +207,7 @@ def initialize_ee(project: str = None, credentials: Any = None) -> bool:
             else:
                 ee.Initialize()
         _ee_initialized = True
+        _clear_tile_url_cache()
 
         QgsMessageLog.logMessage(
             "Earth Engine initialized successfully!",
@@ -163,6 +245,8 @@ def try_auto_initialize_ee() -> bool:
     if ee is None:
         return False
 
+    _set_ee_user_agent_once()
+
     project = os.environ.get("EE_PROJECT_ID", None)
     if not project:
         return False
@@ -170,6 +254,8 @@ def try_auto_initialize_ee() -> bool:
     try:
         ee.Initialize(project=project)
         _ee_initialized = True
+        _clear_tile_url_cache()
+
         QgsMessageLog.logMessage(
             f"Earth Engine auto-initialized with project: {project}",
             "GEE Data Catalogs",
@@ -188,12 +274,20 @@ def try_auto_initialize_ee() -> bool:
 def get_ee_tile_url(
     ee_object: Any,
     vis_params: Optional[Dict] = None,
+    name: str = "",
 ) -> str:
     """Get an XYZ tile URL for an Earth Engine object.
 
+    The synchronous ``getMapId()`` call to Earth Engine can take several
+    seconds on first request. The result is cached in ``_tile_url_cache`` so
+    repeated adds of the same (object, vis_params) pair return instantly.
+    Wall-clock timing is logged on every cache miss so that "slow" can be
+    distinguished from "hung" in the QGIS Log Messages panel.
+
     Args:
-        ee_object: An Earth Engine Image or ImageCollection.
+        ee_object: An Earth Engine Image, ImageCollection, or FeatureCollection.
         vis_params: Visualization parameters dictionary.
+        name: Optional layer name, used only in log messages for clarity.
 
     Returns:
         XYZ tile URL string.
@@ -209,11 +303,47 @@ def get_ee_tile_url(
     if isinstance(ee_object, ee.ImageCollection):
         ee_object = ee_object.mosaic()
 
-    # Get the map ID
-    map_id_dict = ee_object.getMapId(vis_params)
+    label = f" for '{name}'" if name else ""
 
-    # Construct the tile URL
+    cache_key = _tile_cache_key(ee_object, vis_params)
+    if cache_key is not None:
+        cached = _tile_url_cache.get(cache_key)
+        if cached is not None:
+            QgsMessageLog.logMessage(
+                f"Reusing cached tile URL{label}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Info,
+            )
+            return cached
+
+    started = time.monotonic()
+    try:
+        map_id_dict = ee_object.getMapId(vis_params)
+    except Exception as exc:
+        elapsed = time.monotonic() - started
+        QgsMessageLog.logMessage(
+            f"Earth Engine getMapId failed after {elapsed:.2f}s{label}: {exc}",
+            "GEE Data Catalogs",
+            Qgis.MessageLevel.Warning,
+        )
+        raise
+
+    elapsed = time.monotonic() - started
+    QgsMessageLog.logMessage(
+        f"Earth Engine getMapId completed in {elapsed:.2f}s{label}",
+        "GEE Data Catalogs",
+        Qgis.MessageLevel.Info,
+    )
+
     tile_url = map_id_dict.get("tile_fetcher").url_format
+
+    if cache_key is not None and tile_url:
+        if len(_tile_url_cache) >= _TILE_CACHE_CAP:
+            # FIFO eviction: drop the oldest entry (insertion order is
+            # preserved by dict in Python 3.7+).
+            oldest = next(iter(_tile_url_cache))
+            del _tile_url_cache[oldest]
+        _tile_url_cache[cache_key] = tile_url
 
     return tile_url
 
@@ -235,7 +365,7 @@ def _create_xyz_ee_layer(
 ) -> QgsRasterLayer:
     """Create a QGIS XYZ raster layer for an Earth Engine object."""
     if isinstance(ee_object, (ee.Image, ee.ImageCollection)):
-        tile_url = get_ee_tile_url(ee_object, vis_params)
+        tile_url = get_ee_tile_url(ee_object, vis_params, name=name)
         uri = _xyz_uri_from_tile_url(tile_url)
         return QgsRasterLayer(uri, name, "wms")
 
@@ -254,7 +384,7 @@ def _create_xyz_ee_layer(
         styled_fc = ee_object
         if style_params:
             styled_fc = ee_object.style(**style_params)
-        tile_url = get_ee_tile_url(styled_fc, {})
+        tile_url = get_ee_tile_url(styled_fc, {}, name=name)
         uri = _xyz_uri_from_tile_url(tile_url)
         return QgsRasterLayer(uri, name, "wms")
 
@@ -591,9 +721,9 @@ def refresh_ee_layer(layer: QgsRasterLayer) -> bool:
             styled_fc = ee_object
             if style_params:
                 styled_fc = ee_object.style(**style_params)
-            tile_url = get_ee_tile_url(styled_fc, {})
+            tile_url = get_ee_tile_url(styled_fc, {}, name=layer.name())
         else:
-            tile_url = get_ee_tile_url(ee_object, vis_params)
+            tile_url = get_ee_tile_url(ee_object, vis_params, name=layer.name())
 
         # Update layer source
         new_uri = _xyz_uri_from_tile_url(tile_url)

--- a/gee_data_catalogs/core/ee_utils.py
+++ b/gee_data_catalogs/core/ee_utils.py
@@ -28,7 +28,7 @@ _ee_initialized = False
 # Global registry to track EE layers for Inspector
 _ee_layer_registry = {}
 
-# Identifier the earthengine-api sends to Earth Engine on every API call
+# Identifier that the earthengine-api sends to Earth Engine on every API call
 # (getMapId, getInfo, etc.). The official QGIS GEE plugin does the same so EE
 # can attribute traffic and apply the right per-client quotas. This does not
 # affect tile fetches (those go through QGIS's network manager), only the

--- a/gee_data_catalogs/core/tool_timing_hook.py
+++ b/gee_data_catalogs/core/tool_timing_hook.py
@@ -18,13 +18,28 @@ import time
 from typing import Any, Dict, List, Optional
 
 from qgis.core import Qgis, QgsMessageLog
-from strands.hooks import HookProvider, HookRegistry
-from strands.hooks.events import (
-    AfterModelCallEvent,
-    AfterToolCallEvent,
-    BeforeModelCallEvent,
-    BeforeToolCallEvent,
-)
+
+try:
+    from strands.hooks import HookProvider, HookRegistry
+    from strands.hooks.events import (
+        AfterModelCallEvent,
+        AfterToolCallEvent,
+        BeforeModelCallEvent,
+        BeforeToolCallEvent,
+    )
+except ImportError:  # pragma: no cover
+    # Strands is an AI Assistant runtime dependency, not a hard plugin
+    # dependency. Fall back to stubs so this module still imports cleanly
+    # under environments without Strands (e.g. the PyQt6 import-smoke CI
+    # job, or QGIS sessions where the user has not installed GeoAgent).
+    # ``register_hooks`` is only invoked when a real Strands agent is
+    # present, so the stub event sentinels are never actually consumed.
+    HookProvider = object  # type: ignore[assignment,misc]
+    HookRegistry = Any  # type: ignore[assignment,misc]
+    AfterModelCallEvent = Any  # type: ignore[assignment,misc]
+    AfterToolCallEvent = Any  # type: ignore[assignment,misc]
+    BeforeModelCallEvent = Any  # type: ignore[assignment,misc]
+    BeforeToolCallEvent = Any  # type: ignore[assignment,misc]
 
 PLUGIN_NAME = "GEE Data Catalogs"
 

--- a/gee_data_catalogs/core/tool_timing_hook.py
+++ b/gee_data_catalogs/core/tool_timing_hook.py
@@ -1,0 +1,191 @@
+"""Per-step wall-clock timing hook for the AI Assistant.
+
+Registers with the underlying Strands agent's hook registry to capture the
+duration of every model (LLM) call AND every tool call in chronological
+order. Each completion is logged to the QGIS Log Messages panel so users
+can see exactly where the seconds in a long chat turn went, and the same
+data is exposed as a list the AI Assistant panel renders next to the total
+elapsed time.
+
+The breakdown distinguishes "LLM call" entries (one per round-trip to the
+provider) from tool entries, so you can tell whether a slow turn is many
+fast LLM calls, one slow LLM call, or actual tool work.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+from qgis.core import Qgis, QgsMessageLog
+from strands.hooks import HookProvider, HookRegistry
+from strands.hooks.events import (
+    AfterModelCallEvent,
+    AfterToolCallEvent,
+    BeforeModelCallEvent,
+    BeforeToolCallEvent,
+)
+
+PLUGIN_NAME = "GEE Data Catalogs"
+
+
+def _tool_use_id(use: Any) -> Optional[str]:
+    """Return the tool_use_id from a Strands tool_use dict, if present."""
+    if not isinstance(use, dict):
+        return None
+    return use.get("toolUseId") or use.get("tool_use_id")
+
+
+class ToolTimingHookProvider(HookProvider):
+    """Strands hook provider that records per-step wall-clock durations.
+
+    Captures both tool calls and LLM round-trips. Each completed step is
+    appended to ``timings`` in chronological order with a ``kind`` field
+    (``"tool"`` or ``"model"``) so callers can render a clear breakdown.
+    """
+
+    def __init__(self) -> None:
+        self._tool_starts: Dict[str, float] = {}
+        self._model_start: Optional[float] = None
+        self._model_call_count: int = 0
+        self.timings: List[Dict[str, Any]] = []
+
+    def register_hooks(
+        self, registry: HookRegistry, **kwargs: Any
+    ) -> None:  # noqa: ARG002
+        """Register before/after callbacks for tool and model events."""
+        registry.add_callback(BeforeToolCallEvent, self._before_tool)
+        registry.add_callback(AfterToolCallEvent, self._after_tool)
+        registry.add_callback(BeforeModelCallEvent, self._before_model)
+        registry.add_callback(AfterModelCallEvent, self._after_model)
+
+    def _before_tool(self, event: BeforeToolCallEvent) -> None:
+        """Record a monotonic start time keyed by tool_use_id."""
+        use = event.tool_use
+        tool_use_id = _tool_use_id(use)
+        if tool_use_id is None:
+            return
+        self._tool_starts[tool_use_id] = time.monotonic()
+
+    def _after_tool(self, event: AfterToolCallEvent) -> None:
+        """Compute the elapsed time, log it, and append a timing record."""
+        use = event.tool_use
+        tool_use_id = _tool_use_id(use)
+        name = str(use.get("name", "")) if isinstance(use, dict) else ""
+
+        started = self._tool_starts.pop(tool_use_id, None) if tool_use_id else None
+        elapsed = time.monotonic() - started if started is not None else None
+
+        failed = event.exception is not None
+        record: Dict[str, Any] = {
+            "kind": "tool",
+            "name": name,
+            "duration": elapsed,
+            "failed": failed,
+        }
+        self.timings.append(record)
+
+        if elapsed is None:
+            return
+
+        if failed:
+            QgsMessageLog.logMessage(
+                f"Tool '{name}' failed after {elapsed:.2f}s: {event.exception}",
+                PLUGIN_NAME,
+                Qgis.MessageLevel.Warning,
+            )
+        else:
+            QgsMessageLog.logMessage(
+                f"Tool '{name}' completed in {elapsed:.2f}s",
+                PLUGIN_NAME,
+                Qgis.MessageLevel.Info,
+            )
+
+    def _before_model(self, event: BeforeModelCallEvent) -> None:  # noqa: ARG002
+        """Record the start of an LLM round-trip."""
+        self._model_start = time.monotonic()
+
+    def _after_model(self, event: AfterModelCallEvent) -> None:
+        """Compute LLM round-trip duration, log it, and append a record."""
+        started = self._model_start
+        self._model_start = None
+        elapsed = time.monotonic() - started if started is not None else None
+
+        self._model_call_count += 1
+        name = f"LLM call #{self._model_call_count}"
+        failed = event.exception is not None
+
+        record: Dict[str, Any] = {
+            "kind": "model",
+            "name": name,
+            "duration": elapsed,
+            "failed": failed,
+        }
+        self.timings.append(record)
+
+        if elapsed is None:
+            return
+
+        if failed:
+            QgsMessageLog.logMessage(
+                f"{name} failed after {elapsed:.2f}s: {event.exception}",
+                PLUGIN_NAME,
+                Qgis.MessageLevel.Warning,
+            )
+        else:
+            QgsMessageLog.logMessage(
+                f"{name} completed in {elapsed:.2f}s",
+                PLUGIN_NAME,
+                Qgis.MessageLevel.Info,
+            )
+
+
+def format_tool_timings(
+    timings: List[Dict[str, Any]],
+    total_elapsed: Optional[float] = None,
+) -> str:
+    """Render a per-step timing breakdown for the chat panel.
+
+    Renders entries in chronological order (the order they completed) with
+    LLM round-trips and tool calls interleaved so users can see whether a
+    slow turn is dominated by model latency, by tool execution, or by
+    framework overhead.
+
+    Args:
+        timings: List of {kind, name, duration, failed} records from
+            :class:`ToolTimingHookProvider`.
+        total_elapsed: Optional total chat turn duration in seconds. When
+            provided, a final "Other" line is added showing the residual
+            time inside ``agent.chat()`` that was not spent in any
+            recorded step (typically Strands framework overhead).
+
+    Returns:
+        A multi-line string suitable for appending to the chat reply.
+    """
+    if not timings:
+        return ""
+
+    lines = ["Per-step timing:"]
+    accounted = 0.0
+    have_durations = False
+    for record in timings:
+        name = record.get("name") or "(unknown)"
+        duration = record.get("duration")
+        failed = record.get("failed")
+        if duration is None:
+            lines.append(f"  - {name}: n/a")
+            continue
+        have_durations = True
+        accounted += duration
+        suffix = " [failed]" if failed else ""
+        lines.append(f"  - {name}: {duration:.2f}s{suffix}")
+
+    if (
+        total_elapsed is not None
+        and have_durations
+        and total_elapsed > accounted + 0.05
+    ):
+        other = total_elapsed - accounted
+        lines.append(f"  - Other: {other:.2f}s")
+
+    return "\n".join(lines)

--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -28,6 +28,11 @@ REQUIRED_PACKAGES = [
     ("GeoAgent", "[providers]>=1.1.1"),
 ]
 
+# Module-level guard so the "added venv site-packages to sys.path" message
+# logs at most once per QGIS session, even though the function may be called
+# on every AI Assistant prompt and tool invocation.
+_sys_path_logged = False
+
 
 def _log(message: str, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
@@ -863,26 +868,40 @@ def verify_venv(
 
 
 def ensure_venv_packages_available() -> bool:
-    """Make venv packages importable by adding site-packages to sys.path.
+    """Add the dedicated venv's site-packages to ``sys.path`` if it exists.
 
-    Also patches the 'ee' module into any already-loaded modules that had
-    set ee = None due to ImportError before the venv was available.
+    This is a quiet, idempotent best-effort helper: when the dedicated venv
+    at ``VENV_DIR`` is missing, it silently returns False and lets the caller
+    rely on whatever Python environment is currently active (conda, system
+    pip, pixi, etc.). The actual presence of required packages is reported
+    by :func:`check_dependencies`, which uses ``importlib.metadata`` and
+    therefore picks up packages from any source.
+
+    Mirrors the pattern used by the sibling ``open_geoagent`` plugin so the
+    two plugins stay aligned and produce no spurious warnings on every AI
+    Assistant prompt.
+
+    Also patches the ``ee`` module into any already-loaded modules that had
+    set ``ee = None`` due to ImportError before the venv was on sys.path.
 
     Returns:
-        True if venv packages are available, False otherwise.
+        True if the venv site-packages was added or already present.
+        False if the venv does not exist or its site-packages cannot be located.
     """
+    global _sys_path_logged
+
     if not venv_exists():
-        _log("Venv does not exist, cannot load packages", Qgis.MessageLevel.Warning)
         return False
 
     site_packages = get_venv_site_packages()
     if site_packages is None:
-        _log(f"Venv site-packages not found in: {VENV_DIR}", Qgis.MessageLevel.Warning)
         return False
 
     if site_packages not in sys.path:
         sys.path.insert(0, site_packages)
-        _log(f"Added venv site-packages to sys.path: {site_packages}")
+        if not _sys_path_logged:
+            _log(f"Added venv site-packages to sys.path: {site_packages}")
+            _sys_path_logged = True
 
     # Patch ee into already-loaded modules that cached ee = None at import time
     _patch_ee_module()

--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -432,7 +432,35 @@ class ChatWorker(QThread):
                     confirm=self._confirm_tool,
                 )
 
+            # Capture per-tool wall-clock timing so the user can see where the
+            # seconds in a long chat turn go (LLM round-trips vs tool exec).
+            # Strands' ``Agent.add_hook`` expects a single callback function;
+            # to register a full ``HookProvider`` post-construction we route
+            # through ``Agent.hooks.register_hooks`` (or ``add_hook`` on the
+            # registry, depending on Strands version). HookProvider's own
+            # ``register_hooks`` method accepts a registry, so we call that.
+            timing_hook = None
+            try:
+                from ..core.tool_timing_hook import ToolTimingHookProvider
+
+                timing_hook = ToolTimingHookProvider()
+                hook_registry = agent.strands_agent.hooks
+                if hasattr(hook_registry, "add_hook"):
+                    hook_registry.add_hook(timing_hook)
+                else:
+                    timing_hook.register_hooks(hook_registry)
+            except Exception as exc:
+                # Non-fatal: a missing/changed Strands hook API should not
+                # break the chat. Log and continue without per-tool timing.
+                timing_hook = None
+                QgsMessageLog.logMessage(
+                    f"Could not attach tool timing hook: {exc}",
+                    "GEE Data Catalogs",
+                    Qgis.Warning,
+                )
+
             response = agent.chat(self.prompt)
+            tool_timings = list(timing_hook.timings) if timing_hook else []
             snippets = _extract_earth_engine_snippets(response.tool_calls)
             if not snippets:
                 snippets = _extract_python_code_blocks(response.answer_text or "")
@@ -445,6 +473,8 @@ class ChatWorker(QThread):
                         "tools": ", ".join(response.executed_tools or []),
                         "cancelled": ", ".join(response.cancelled_tools or []),
                         "elapsed": f"{response.execution_time:.2f}s",
+                        "elapsed_seconds": float(response.execution_time or 0.0),
+                        "tool_timings": tool_timings,
                         "snippets": [],
                         "cancelled_by_user": True,
                     }
@@ -458,6 +488,8 @@ class ChatWorker(QThread):
                     "tools": ", ".join(response.executed_tools or []),
                     "cancelled": ", ".join(response.cancelled_tools or []),
                     "elapsed": f"{response.execution_time:.2f}s",
+                    "elapsed_seconds": float(response.execution_time or 0.0),
+                    "tool_timings": tool_timings,
                     "snippets": snippets,
                     "cancelled_by_user": False,
                 }
@@ -531,9 +563,14 @@ class ChatPanelWidget(QWidget):
         self.auto_approve_tools_check.setToolTip(
             "Run confirmation-required tools without prompting for this session."
         )
+        self.show_timing_check = QCheckBox("Per-step timing")
+        self.show_timing_check.setToolTip(
+            "Show per-tool and per-LLM-call elapsed times beneath each reply."
+        )
         mode_layout = QHBoxLayout()
         mode_layout.addWidget(self.fast_check)
         mode_layout.addWidget(self.auto_approve_tools_check)
+        mode_layout.addWidget(self.show_timing_check)
         mode_layout.addStretch(1)
         model_layout.addRow("", mode_layout)
         layout.addWidget(model_group)
@@ -618,6 +655,9 @@ class ChatPanelWidget(QWidget):
         self.auto_approve_tools_check.setChecked(
             _setting(self.settings, "auto_approve_tools", False, bool)
         )
+        self.show_timing_check.setChecked(
+            _setting(self.settings, "show_timing", True, bool)
+        )
 
     def _save_model_settings(self):
         """Persist the selected provider, model, and mode settings."""
@@ -631,6 +671,10 @@ class ChatPanelWidget(QWidget):
         self.settings.setValue(
             f"{SETTINGS_PREFIX}auto_approve_tools",
             self.auto_approve_tools_check.isChecked(),
+        )
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}show_timing",
+            self.show_timing_check.isChecked(),
         )
 
     def _on_provider_changed(self, provider):
@@ -802,6 +846,16 @@ class ChatPanelWidget(QWidget):
                 details.append(f"Tools: {result['tools']}")
             if result.get("elapsed"):
                 details.append(f"Elapsed: {result['elapsed']}")
+            tool_timings = result.get("tool_timings") or []
+            if tool_timings and self.show_timing_check.isChecked():
+                from ..core.tool_timing_hook import format_tool_timings
+
+                breakdown = format_tool_timings(
+                    tool_timings,
+                    total_elapsed=result.get("elapsed_seconds"),
+                )
+                if breakdown:
+                    details.append(breakdown)
             if details:
                 answer = f"{answer}\n\n" + "\n".join(details)
             self._append_message("GeoAgent", answer, markdown=True)

--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -456,7 +456,7 @@ class ChatWorker(QThread):
                 QgsMessageLog.logMessage(
                     f"Could not attach tool timing hook: {exc}",
                     "GEE Data Catalogs",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
 
             response = agent.chat(self.prompt)
@@ -566,6 +566,12 @@ class ChatPanelWidget(QWidget):
         self.show_timing_check = QCheckBox("Per-step timing")
         self.show_timing_check.setToolTip(
             "Show per-tool and per-LLM-call elapsed times beneath each reply."
+        )
+        # Persist immediately on toggle so the preference survives a QGIS
+        # restart even if the user closes the dock without sending another
+        # prompt (otherwise it would only save inside ``_send_prompt``).
+        self.show_timing_check.toggled.connect(
+            lambda _checked: self._save_model_settings()
         )
         mode_layout = QHBoxLayout()
         mode_layout.addWidget(self.fast_check)


### PR DESCRIPTION
## Summary

- **Silence the per-prompt venv warning.** `ensure_venv_packages_available()` now returns `False` quietly when the dedicated venv is absent, mirroring the sibling `open_geoagent` plugin so conda / system-Python installs no longer log a warning on every AI Assistant prompt. The one-time `sys.path` injection INFO line is gated behind a session-level flag.
- **Make EE layer adds observable and faster on repeat.** `get_ee_tile_url()` is wrapped with wall-clock timing (`Earth Engine getMapId completed in N.NNs`) and a `_tile_url_cache` keyed by `ee_object.serialize()` + sorted vis_params (FIFO cap 64). Repeated adds of the same dataset skip the network round-trip. Cache is cleared on every successful EE re-init. `ee.data.setUserAgent("qgis-gee-data-catalogs-plugin/0.11.0")` is set once so EE can attribute traffic to this plugin (matches the official `ee_plugin` approach).
- **Expose per-step timing in the chat panel.** New `tool_timing_hook.py` registers a Strands `HookProvider` on `agent.strands_agent.hooks` to record per-tool and per-LLM-call durations. The breakdown shows interleaved chronologically, e.g.:
  ```
  Per-step timing:
    - LLM call #1: 4.56s
    - load_gee_dataset: 0.45s
    - LLM call #2: 3.70s
  ```
  Each step is also logged individually to the QGIS Log Messages panel.
- **Toggle**: a new "Per-step timing" checkbox lives next to "Auto approve running tools" in the AI Assistant panel and persists via QSettings (default on). Unchecking hides the per-step block from chat replies; per-step events still log to the QGIS log either way.

## Test plan

- [ ] Reload the plugin in QGIS with conda env that already has `earthengine-api`, `geemap`, `GeoAgent`. Submit several AI Assistant prompts. Verify there are zero `WARNING Venv does not exist` lines in the QGIS Log Messages panel.
- [ ] Ask the assistant to add the same EE dataset twice. First add logs `INFO Earth Engine getMapId completed in N.NNs`. Second add logs `INFO Reusing cached tile URL` and completes in well under a second.
- [ ] Re-initialize EE (or restart auth). Confirm the cached URL is dropped (a fresh `getMapId` log appears).
- [ ] Send a multi-tool prompt and confirm the chat reply includes a `Per-step timing:` block with one entry per LLM call and per tool, plus an `Other` line if anything is unaccounted for.
- [ ] Untick the new "Per-step timing" checkbox. Confirm the breakdown no longer appears in chat replies, but per-step lines still appear in the QGIS Log Messages panel. Restart QGIS and confirm the unticked state persists.
- [ ] Use the catalog browser "Add to Map" on a Sentinel-2 dataset to confirm the timing log fires there too and no regressions in the existing path.
- [ ] Reopen a saved project containing EE layers (project-reload path from a330798) and confirm layers re-bind without regressions.
- [ ] `pre-commit run --all-files` is clean.