### PR TITLE
feat(ai): stream GeoAgent chat output incrementally

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A comprehensive QGIS plugin for browsing, searching, and loading Google Earth En
 - **Conversion**: Convert Earth Engine JavaScript API to Python API
 - **Inspector**: Inspect Earth Engine layer values at specific locations
 - **Export**: Export Earth Engine layers to various file formats
+- **AI Assistant**: Ask GeoAgent about Earth Engine datasets and QGIS map actions, with streaming output enabled by default
 - **Multiple Data Types**: Load EE Image, ImageCollection, and FeatureCollection layers
 - **Integration**: Works seamlessly with [qgis-geemap-plugin](https://github.com/opengeos/qgis-geemap-plugin)
 - **Update Checker**: Built-in plugin update checker from GitHub

--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -250,6 +250,20 @@ def _extract_earth_engine_snippets(value):
     return snippets
 
 
+def _collect_agent_turn_state(agent):
+    """Read per-turn tool-call state recorded on a GeoAgent instance.
+
+    GeoAgent's ``Agent`` populates ``_tool_calls`` and ``_cancelled`` via its
+    confirmation hook during both ``chat`` and ``stream_chat``. The non-streaming
+    path reads them through ``GeoAgentResponse``; streaming has no equivalent
+    response object today, so we read the same attributes directly. ``getattr``
+    keeps this resilient if a future GeoAgent release renames or removes them.
+    """
+    tool_calls = list(getattr(agent, "_tool_calls", []) or [])
+    cancelled = list(getattr(agent, "_cancelled", []) or [])
+    return tool_calls, cancelled
+
+
 def _format_tool_confirmation_details(tool_name, args):
     """Return readable confirmation details for a GeoAgent tool request."""
     args = args if isinstance(args, dict) else {}
@@ -538,7 +552,7 @@ class ChatWorker(QThread):
         asyncio.run(_collect_stream())
 
         answer = "".join(chunks)
-        tool_calls = list(getattr(agent, "_tool_calls", []) or [])
+        tool_calls, cancelled_tools = _collect_agent_turn_state(agent)
         snippets = _extract_earth_engine_snippets(tool_calls)
         if not snippets:
             snippets = _extract_python_code_blocks(answer)
@@ -561,7 +575,7 @@ class ChatWorker(QThread):
                 "answer": answer,
                 "error": "" if success else f"stop_reason={stop_reason}",
                 "tools": ", ".join(executed_tools),
-                "cancelled": ", ".join(getattr(agent, "_cancelled", []) or []),
+                "cancelled": ", ".join(cancelled_tools),
                 "elapsed": f"{elapsed_seconds:.2f}s",
                 "elapsed_seconds": elapsed_seconds,
                 "tool_timings": tool_timings,
@@ -587,6 +601,11 @@ class ChatPanelWidget(QWidget):
         self._latest_snippet = ""
         self._streaming_message_index = None
         self._streaming_answer = ""
+        self._pending_chunks = []
+        self._chunk_flush_timer = QTimer(self)
+        self._chunk_flush_timer.setSingleShot(True)
+        self._chunk_flush_timer.setInterval(80)
+        self._chunk_flush_timer.timeout.connect(self._flush_pending_chunks)
         self._status_started_at = None
         self._status_base_text = "Running"
         self._status_frame = 0
@@ -914,6 +933,9 @@ class ChatPanelWidget(QWidget):
     def _on_worker_finished(self, result):
         """Render the completed chat worker result."""
         self._stop_running_status()
+        if self._chunk_flush_timer.isActive():
+            self._chunk_flush_timer.stop()
+        self._flush_pending_chunks()
         if result.get("cancelled_by_user"):
             self._latest_snippet = ""
             self.copy_snippet_btn.setEnabled(False)
@@ -972,16 +994,28 @@ class ChatPanelWidget(QWidget):
         self._worker = None
         self._streaming_message_index = None
         self._streaming_answer = ""
+        self._pending_chunks.clear()
 
     def _on_worker_chunk(self, chunk):
-        """Render a streamed model text chunk."""
+        """Buffer a streamed model text chunk for coalesced rendering."""
         if not chunk:
             return
         if self._streaming_message_index is None:
             self._streaming_message_index = len(self._messages)
             self._messages.append({"sender": "GeoAgent", "body": "", "markdown": True})
             self.copy_md_btn.setEnabled(True)
-        self._streaming_answer += chunk
+        self._pending_chunks.append(chunk)
+        if not self._chunk_flush_timer.isActive():
+            self._chunk_flush_timer.start()
+
+    def _flush_pending_chunks(self):
+        """Append buffered chunks to the streaming message in one transcript pass."""
+        if not self._pending_chunks:
+            return
+        self._streaming_answer += "".join(self._pending_chunks)
+        self._pending_chunks.clear()
+        if self._streaming_message_index is None:
+            return
         self._update_message(
             self._streaming_message_index,
             self._streaming_answer,

--- a/gee_data_catalogs/dialogs/chat_dock.py
+++ b/gee_data_catalogs/dialogs/chat_dock.py
@@ -1,5 +1,6 @@
 """Dockable AI assistant for the GEE Data Catalogs plugin."""
 
+import asyncio
 import ast
 import html
 import json
@@ -320,6 +321,7 @@ class ChatWorker(QThread):
     """Run GeoAgent chat without blocking the QGIS UI."""
 
     finished = pyqtSignal(dict)
+    chunk_received = pyqtSignal(str)
 
     def __init__(
         self,
@@ -332,6 +334,7 @@ class ChatWorker(QThread):
         max_tokens,
         auto_approve_tools=False,
         parent=None,
+        stream=False,
     ):
         super().__init__(parent)
         self.iface = iface
@@ -342,6 +345,7 @@ class ChatWorker(QThread):
         self.fast = fast
         self.max_tokens = max_tokens
         self.auto_approve_tools = bool(auto_approve_tools)
+        self.stream = bool(stream)
 
     def _confirm_tool(self, request):
         """Ask the QGIS user before running confirmation-required tools."""
@@ -459,6 +463,10 @@ class ChatWorker(QThread):
                     Qgis.MessageLevel.Warning,
                 )
 
+            if self.stream:
+                self._run_streaming_chat(agent, timing_hook)
+                return
+
             response = agent.chat(self.prompt)
             tool_timings = list(timing_hook.timings) if timing_hook else []
             snippets = _extract_earth_engine_snippets(response.tool_calls)
@@ -507,6 +515,62 @@ class ChatWorker(QThread):
                 }
             )
 
+    def _run_streaming_chat(self, agent, timing_hook):
+        """Stream one chat turn and emit text chunks as they arrive."""
+        started_at = time.time()
+        chunks = []
+        final_result = None
+
+        async def _collect_stream():
+            nonlocal final_result
+            async for event in agent.stream_chat(self.prompt):
+                if self.isInterruptionRequested():
+                    break
+                if not isinstance(event, dict):
+                    continue
+                if "data" in event:
+                    chunk = str(event["data"])
+                    chunks.append(chunk)
+                    self.chunk_received.emit(chunk)
+                if "result" in event:
+                    final_result = event["result"]
+
+        asyncio.run(_collect_stream())
+
+        answer = "".join(chunks)
+        tool_calls = list(getattr(agent, "_tool_calls", []) or [])
+        snippets = _extract_earth_engine_snippets(tool_calls)
+        if not snippets:
+            snippets = _extract_python_code_blocks(answer)
+        tool_timings = list(timing_hook.timings) if timing_hook else []
+        elapsed_seconds = time.time() - started_at
+        tool_metrics = getattr(
+            getattr(final_result, "metrics", None), "tool_metrics", {}
+        )
+        executed_tools = (
+            list(tool_metrics.keys()) if isinstance(tool_metrics, dict) else []
+        )
+        stop_reason = str(getattr(final_result, "stop_reason", "end_turn"))
+        success = stop_reason not in ("cancelled", "guardrail_intervened")
+        if self.isInterruptionRequested():
+            success = False
+
+        self.finished.emit(
+            {
+                "success": success,
+                "answer": answer,
+                "error": "" if success else f"stop_reason={stop_reason}",
+                "tools": ", ".join(executed_tools),
+                "cancelled": ", ".join(getattr(agent, "_cancelled", []) or []),
+                "elapsed": f"{elapsed_seconds:.2f}s",
+                "elapsed_seconds": elapsed_seconds,
+                "tool_timings": tool_timings,
+                "snippets": snippets,
+                "cancelled_by_user": self.isInterruptionRequested(),
+                "streamed": True,
+            }
+        )
+
 
 class ChatPanelWidget(QWidget):
     """Widget that sends user prompts to a GeoAgent catalog agent."""
@@ -521,6 +585,8 @@ class ChatPanelWidget(QWidget):
         self._history_index = None
         self._messages = []
         self._latest_snippet = ""
+        self._streaming_message_index = None
+        self._streaming_answer = ""
         self._status_started_at = None
         self._status_base_text = "Running"
         self._status_frame = 0
@@ -559,9 +625,13 @@ class ChatPanelWidget(QWidget):
         model_layout.addRow("Model:", self.model_input)
 
         self.fast_check = QCheckBox("Fast mode")
+        self.stream_check = QCheckBox("Stream output")
         self.auto_approve_tools_check = QCheckBox("Auto approve running tools")
         self.auto_approve_tools_check.setToolTip(
             "Run confirmation-required tools without prompting for this session."
+        )
+        self.stream_check.setToolTip(
+            "Show model text as it arrives instead of waiting for the full response."
         )
         self.show_timing_check = QCheckBox("Per-step timing")
         self.show_timing_check.setToolTip(
@@ -575,6 +645,7 @@ class ChatPanelWidget(QWidget):
         )
         mode_layout = QHBoxLayout()
         mode_layout.addWidget(self.fast_check)
+        mode_layout.addWidget(self.stream_check)
         mode_layout.addWidget(self.auto_approve_tools_check)
         mode_layout.addWidget(self.show_timing_check)
         mode_layout.addStretch(1)
@@ -658,6 +729,7 @@ class ChatPanelWidget(QWidget):
             model = DEFAULT_MODELS.get(self.provider_combo.currentText(), "")
         self.model_input.setText(model)
         self.fast_check.setChecked(_setting(self.settings, "fast_mode", False, bool))
+        self.stream_check.setChecked(_setting(self.settings, "stream_chat", True, bool))
         self.auto_approve_tools_check.setChecked(
             _setting(self.settings, "auto_approve_tools", False, bool)
         )
@@ -673,6 +745,9 @@ class ChatPanelWidget(QWidget):
         self.settings.setValue(f"{SETTINGS_PREFIX}model", self.model_input.text())
         self.settings.setValue(
             f"{SETTINGS_PREFIX}fast_mode", self.fast_check.isChecked()
+        )
+        self.settings.setValue(
+            f"{SETTINGS_PREFIX}stream_chat", self.stream_check.isChecked()
         )
         self.settings.setValue(
             f"{SETTINGS_PREFIX}auto_approve_tools",
@@ -737,16 +812,21 @@ class ChatPanelWidget(QWidget):
         if model_id and not self.model_input.text().strip():
             self.model_input.setText(model_id)
         fast = self.fast_check.isChecked()
+        stream = self.stream_check.isChecked()
         auto_approve_tools = self.auto_approve_tools_check.isChecked()
         max_tokens = self.settings.value(f"{SETTINGS_PREFIX}max_tokens", 4096, type=int)
         prompt_with_context = self._build_prompt_with_context(prompt)
 
         self._latest_snippet = ""
+        self._streaming_message_index = None
+        self._streaming_answer = ""
         self.copy_snippet_btn.setEnabled(False)
         self._append_message("You", prompt, markdown=False)
         self.prompt_input.clear()
         self.status_label.setStyleSheet("color: #1976D2; font-size: 10px;")
-        self._start_running_status("Running GeoAgent")
+        self._start_running_status(
+            "Streaming GeoAgent" if stream else "Running GeoAgent"
+        )
         self.send_btn.setEnabled(False)
         self.cancel_btn.setEnabled(True)
 
@@ -760,7 +840,9 @@ class ChatPanelWidget(QWidget):
             max_tokens,
             auto_approve_tools,
             self,
+            stream=stream,
         )
+        self._worker.chunk_received.connect(self._on_worker_chunk)
         self._worker.finished.connect(self._on_worker_finished)
         self._worker.start()
 
@@ -864,7 +946,14 @@ class ChatPanelWidget(QWidget):
                     details.append(breakdown)
             if details:
                 answer = f"{answer}\n\n" + "\n".join(details)
-            self._append_message("GeoAgent", answer, markdown=True)
+            if result.get("streamed") and self._streaming_message_index is not None:
+                self._update_message(
+                    self._streaming_message_index,
+                    answer,
+                    markdown=True,
+                )
+            else:
+                self._append_message("GeoAgent", answer, markdown=True)
             self.status_label.setText("Ready")
             self.status_label.setStyleSheet("color: gray; font-size: 10px;")
         else:
@@ -881,6 +970,23 @@ class ChatPanelWidget(QWidget):
         self.send_btn.setEnabled(True)
         self.cancel_btn.setEnabled(False)
         self._worker = None
+        self._streaming_message_index = None
+        self._streaming_answer = ""
+
+    def _on_worker_chunk(self, chunk):
+        """Render a streamed model text chunk."""
+        if not chunk:
+            return
+        if self._streaming_message_index is None:
+            self._streaming_message_index = len(self._messages)
+            self._messages.append({"sender": "GeoAgent", "body": "", "markdown": True})
+            self.copy_md_btn.setEnabled(True)
+        self._streaming_answer += chunk
+        self._update_message(
+            self._streaming_message_index,
+            self._streaming_answer,
+            markdown=True,
+        )
 
     def _cancel_running_task(self):
         """Request cancellation of the in-flight chat worker."""
@@ -937,6 +1043,15 @@ class ChatPanelWidget(QWidget):
         self.copy_md_btn.setEnabled(bool(self._messages))
         self._render_transcript()
 
+    def _update_message(self, index, message, markdown=False):
+        """Update an existing chat message and refresh the transcript."""
+        if index < 0 or index >= len(self._messages):
+            return
+        self._messages[index]["body"] = message.strip()
+        self._messages[index]["markdown"] = markdown
+        self.copy_md_btn.setEnabled(bool(self._messages))
+        self._render_transcript()
+
     def _render_transcript(self):
         """Render the stored chat messages as HTML."""
         blocks = []
@@ -952,6 +1067,7 @@ class ChatPanelWidget(QWidget):
                 f"{body}"
                 "</div>"
             )
+        blocks.append("<div style='height: 1em;'>&nbsp;</div>")
         self.transcript.setHtml("\n".join(blocks))
         end_cursor = getattr(getattr(QTextCursor, "MoveOperation", QTextCursor), "End")
         self.transcript.moveCursor(end_cursor)

--- a/tests/test_ai_provider_config.py
+++ b/tests/test_ai_provider_config.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import types
 
@@ -11,6 +12,9 @@ class _FakeSettings:
 
     def value(self, key, default="", type=str):  # noqa: A002
         return self.values.get(key, default)
+
+    def setValue(self, key, value):  # noqa: N802
+        self.values[key] = value
 
 
 class _CredentialHarness:
@@ -125,6 +129,10 @@ def test_apply_environment_keeps_existing_env_when_setting_empty(monkeypatch):
     assert chat_dock.os.environ["OPENAI_API_KEY"] == "existing-key"
 
 
+def test_stream_chat_setting_defaults_to_true():
+    assert chat_dock._setting(_FakeSettings(), "stream_chat", True, bool) is True
+
+
 def test_confirm_tool_auto_approve_bypasses_confirmation(monkeypatch):
     class _MessageBox:
         @staticmethod
@@ -182,3 +190,85 @@ def test_confirm_tool_uses_confirmation_when_auto_approve_is_off(monkeypatch):
     request = types.SimpleNamespace(args={"asset_id": "LANDSAT/LC09"}, tool_name="load")
 
     assert not worker._confirm_tool(request)
+
+
+def test_chat_worker_streams_when_enabled(monkeypatch):
+    """ChatWorker.run streams deltas through chunk_received when enabled."""
+    geoagent = types.ModuleType("geoagent")
+
+    class _Config:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class _Hooks:
+        def add_hook(self, _hook):
+            return None
+
+    class _StrandsAgent:
+        hooks = _Hooks()
+
+    class _StubAgent:
+        strands_agent = _StrandsAgent()
+        _tool_calls = []
+        _cancelled = []
+
+        async def stream_chat(self, prompt):
+            captured["prompt"] = prompt
+            yield {"data": "he"}
+            await asyncio.sleep(0)
+            yield {"data": "llo"}
+
+    captured = {}
+
+    def _factory(iface, **kwargs):
+        captured["iface"] = iface
+        captured["kwargs"] = kwargs
+        return _StubAgent()
+
+    geoagent.GeoAgentConfig = _Config
+    geoagent.for_gee_data_catalogs = _factory
+    monkeypatch.setitem(sys.modules, "geoagent", geoagent)
+    monkeypatch.setitem(
+        sys.modules,
+        "qgis.core",
+        types.SimpleNamespace(QgsProject=types.SimpleNamespace(instance=lambda: None)),
+    )
+    timing_module = types.ModuleType("gee_data_catalogs.core.tool_timing_hook")
+
+    class _TimingHook:
+        timings = []
+
+    timing_module.ToolTimingHookProvider = _TimingHook
+    monkeypatch.setitem(
+        sys.modules,
+        "gee_data_catalogs.core.tool_timing_hook",
+        timing_module,
+    )
+
+    sentinel_iface = object()
+    worker = chat_dock.ChatWorker(
+        sentinel_iface,
+        None,
+        "stream please",
+        "openai-codex",
+        "gpt-5.5",
+        True,
+        1024,
+        True,
+        stream=True,
+    )
+
+    chunks = []
+    emitted = {}
+    worker.chunk_received.connect(chunks.append)
+    worker.finished.connect(lambda payload: emitted.setdefault("payload", payload))
+
+    worker.run()
+
+    assert captured["iface"] is sentinel_iface
+    assert captured["prompt"] == "stream please"
+    assert captured["kwargs"]["fast"] is True
+    assert chunks == ["he", "llo"]
+    assert emitted["payload"]["success"] is True
+    assert emitted["payload"]["answer"] == "hello"
+    assert emitted["payload"]["streamed"] is True


### PR DESCRIPTION
## Summary
- Add a "Stream output" toggle (on by default) to the AI assistant dock so the model's reply renders as it arrives.
- Collect streamed deltas via `agent.stream_chat` in the chat worker and emit them to the panel in place of waiting for the full response.
- Update the README feature list to mention the AI assistant with streaming.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `python -m pytest tests/test_ai_provider_config.py`
- [ ] Manually verify in QGIS that streaming produces incremental text and that disabling the toggle restores the original blocking behavior.