### PR TITLE
feat(ee): add explicit auth/init buttons and surface errors

### DIFF
--- a/gee_data_catalogs/core/ee_utils.py
+++ b/gee_data_catalogs/core/ee_utils.py
@@ -173,13 +173,20 @@ def _check_credentials_exist() -> bool:
     return os.path.exists(credentials_path)
 
 
-def initialize_ee(project: str = None, force: bool = False) -> bool:
+def initialize_ee(
+    project: str = None,
+    force: bool = False,
+    credentials: Any = None,
+) -> bool:
     """Initialize Earth Engine.
 
     Args:
         project: Google Cloud project ID. If None, reads from plugin settings
             then EE_PROJECT_ID.
         force: If True, reinitialize even when already initialized.
+        credentials: Optional credentials object (e.g. a service-account
+            ``google.oauth2.service_account.Credentials``). When provided,
+            the on-disk OAuth credentials check is skipped.
 
     Returns:
         True if initialization was successful, False otherwise.
@@ -199,12 +206,15 @@ def initialize_ee(project: str = None, force: bool = False) -> bool:
         _last_init_error = None
         return True
 
+    if force:
+        _ee_initialized = False
+
     if project is None or project.strip() == "":
         project = _get_settings_project()
         if not project:
             project = os.environ.get("EE_PROJECT_ID", None)
 
-    if not _check_credentials_exist():
+    if credentials is None and not _check_credentials_exist():
         _last_init_error = (
             "Earth Engine credentials not found. Open Settings -> Earth Engine "
             "and click 'Authenticate (opens browser)', then retry initialization."
@@ -217,15 +227,18 @@ def initialize_ee(project: str = None, force: bool = False) -> bool:
             "GEE Data Catalogs",
             Qgis.MessageLevel.Info,
         )
+        init_kwargs = {}
         if project:
-            ee.Initialize(project=project)
-        else:
-            ee.Initialize()
+            init_kwargs["project"] = project
+        if credentials is not None:
+            init_kwargs["credentials"] = credentials
+        ee.Initialize(**init_kwargs)
         _ee_initialized = True
         _last_init_error = None
         _clear_tile_url_cache()
         return True
     except Exception as e:
+        _ee_initialized = False
         project_desc = f"project={project!r}" if project else "no project"
         _last_init_error = (
             f"ee.Initialize({project_desc}) failed: {e!r}. "
@@ -241,7 +254,7 @@ def try_auto_initialize_ee() -> bool:
     Returns:
         True if initialization was successful, False otherwise.
     """
-    global _ee_initialized
+    global _ee_initialized, _last_init_error
 
     if _ee_initialized:
         return True

--- a/gee_data_catalogs/core/ee_utils.py
+++ b/gee_data_catalogs/core/ee_utils.py
@@ -24,6 +24,7 @@ from qgis.core import (
 
 # Track if EE has been initialized
 _ee_initialized = False
+_last_init_error: Optional[str] = None
 
 # Global registry to track EE layers for Inspector
 _ee_layer_registry = {}
@@ -136,6 +137,32 @@ def is_ee_initialized() -> bool:
     return _ee_initialized
 
 
+def mark_ee_initialized(value: bool = True) -> None:
+    """Set the cached Earth Engine initialization flag."""
+    global _ee_initialized, _last_init_error
+    _ee_initialized = value
+    if value:
+        _last_init_error = None
+
+
+def get_last_init_error() -> Optional[str]:
+    """Return the most recent Earth Engine initialization error."""
+    return _last_init_error
+
+
+def _get_settings_project() -> Optional[str]:
+    """Read the plugin's configured Earth Engine project ID."""
+    try:
+        from qgis.PyQt.QtCore import QSettings
+
+        settings = QSettings()
+        project = settings.value("GeeDataCatalogs/ee_project", "", type=str)
+        project = project.strip() if project else ""
+        return project or None
+    except Exception:
+        return None
+
+
 def _check_credentials_exist() -> bool:
     """Check if Earth Engine credentials file exists.
 
@@ -146,89 +173,66 @@ def _check_credentials_exist() -> bool:
     return os.path.exists(credentials_path)
 
 
-def initialize_ee(project: str = None, credentials: Any = None) -> bool:
+def initialize_ee(project: str = None, force: bool = False) -> bool:
     """Initialize Earth Engine.
 
     Args:
-        project: Google Cloud project ID.
-        credentials: Optional credentials object.
+        project: Google Cloud project ID. If None, reads from plugin settings
+            then EE_PROJECT_ID.
+        force: If True, reinitialize even when already initialized.
 
     Returns:
         True if initialization was successful, False otherwise.
     """
-    global _ee_initialized
+    global _ee_initialized, _last_init_error
 
     if ee is None:
-        raise ImportError(
-            "The 'ee' module is not installed. Please install earthengine-api."
+        _last_init_error = (
+            "earthengine-api is not loaded. Please install earthengine-api, "
+            "then restart QGIS if prompted."
         )
+        return False
 
     _set_ee_user_agent_once()
 
-    if project is None or project == "":
-        project = os.environ.get("EE_PROJECT_ID", None)
+    if _ee_initialized and not force:
+        _last_init_error = None
+        return True
 
-    # Check if credentials file exists
+    if project is None or project.strip() == "":
+        project = _get_settings_project()
+        if not project:
+            project = os.environ.get("EE_PROJECT_ID", None)
+
     if not _check_credentials_exist():
-        raise RuntimeError(
-            "Earth Engine credentials not found. Please authenticate first:\n\n"
-            "Option 1 - Authenticate via QGIS Python Console (Recommended):\n"
-            "  1. Go to Plugins > Python Console\n"
-            "  2. Run: import ee; ee.Authenticate()\n"
-            "  3. Follow the authentication instructions in your browser\n"
-            "  4. Return to QGIS and initialize Earth Engine again\n\n"
-            "Option 2 - Authenticate via terminal:\n"
-            "  1. Open a terminal\n"
-            "  2. Run: earthengine authenticate\n"
-            "  3. Follow the authentication instructions\n"
-            "  4. Restart QGIS after authentication"
+        _last_init_error = (
+            "Earth Engine credentials not found. Open Settings -> Earth Engine "
+            "and click 'Authenticate (opens browser)', then retry initialization."
         )
+        return False
 
     try:
-        # Log initialization attempt
         QgsMessageLog.logMessage(
             f"Attempting to initialize Earth Engine with project: {project if project else 'None'}",
             "GEE Data Catalogs",
             Qgis.MessageLevel.Info,
         )
-
-        # Initialize without explicitly passing credentials=None
-        # This allows EE to auto-discover credentials from ~/.config/earthengine/
-        if credentials is not None:
-            # Only pass credentials if explicitly provided
-            if project:
-                ee.Initialize(credentials=credentials, project=project)
-            else:
-                ee.Initialize(credentials=credentials)
+        if project:
+            ee.Initialize(project=project)
         else:
-            # Let EE auto-discover credentials from ~/.config/earthengine/
-            if project:
-                ee.Initialize(project=project)
-            else:
-                ee.Initialize()
+            ee.Initialize()
         _ee_initialized = True
+        _last_init_error = None
         _clear_tile_url_cache()
-
-        QgsMessageLog.logMessage(
-            "Earth Engine initialized successfully!",
-            "GEE Data Catalogs",
-            Qgis.MessageLevel.Success,
-        )
         return True
     except Exception as e:
-        error_msg = str(e)
-        if "authentication" in error_msg.lower() or "credential" in error_msg.lower():
-            raise RuntimeError(
-                f"Failed to initialize Earth Engine: {error_msg}\n\n"
-                "Please authenticate using QGIS Python Console:\n"
-                "  1. Go to Plugins > Python Console\n"
-                "  2. Run: import ee; ee.Authenticate()\n"
-                "  3. Follow the browser authentication steps\n"
-                "  4. Try initializing Earth Engine again\n\n"
-                "Note: Make sure you have set your Project ID in Settings."
-            )
-        else:
-            raise RuntimeError(f"Failed to initialize Earth Engine: {error_msg}")
+        project_desc = f"project={project!r}" if project else "no project"
+        _last_init_error = (
+            f"ee.Initialize({project_desc}) failed: {e!r}. "
+            "Open Settings -> Earth Engine, click 'Initialize Earth Engine' "
+            "to retest, then 'Authenticate (opens browser)' if needed."
+        )
+        return False
 
 
 def try_auto_initialize_ee() -> bool:
@@ -247,13 +251,16 @@ def try_auto_initialize_ee() -> bool:
 
     _set_ee_user_agent_once()
 
-    project = os.environ.get("EE_PROJECT_ID", None)
+    project = _get_settings_project()
+    if not project:
+        project = os.environ.get("EE_PROJECT_ID", None)
     if not project:
         return False
 
     try:
         ee.Initialize(project=project)
         _ee_initialized = True
+        _last_init_error = None
         _clear_tile_url_cache()
 
         QgsMessageLog.logMessage(

--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -1297,12 +1297,14 @@ def authenticate_ee(
     env = _get_clean_env_for_venv()
     kwargs = _get_subprocess_kwargs()
 
-    auth_code = "import ee; ee.Authenticate()"
+    # Bind the local OAuth callback on an ephemeral port to avoid collisions
+    # with anything already listening on the earthengine-api default port.
+    auth_code = "import ee; ee.Authenticate(auth_mode='localhost:0')"
 
     if progress_callback:
         progress_callback(50, "Waiting for browser authentication...")
 
-    _log("Running ee.Authenticate() in venv...")
+    _log("Running ee.Authenticate(auth_mode='localhost:0') in venv...")
 
     try:
         result = subprocess.run(  # nosec B603
@@ -1321,8 +1323,11 @@ def authenticate_ee(
             return True, "Earth Engine authentication completed successfully"
         else:
             error = result.stderr or result.stdout or "Unknown error"
-            _log(f"EE authentication failed: {error[:200]}", Qgis.MessageLevel.Warning)
-            return False, f"Authentication failed: {error[:200]}"
+            _log(f"EE authentication failed:\n{error}", Qgis.MessageLevel.Warning)
+            return False, (
+                f"Authentication failed: {error[:500]}"
+                "\n\n(Full traceback in the QGIS Message Log -> GEE Data Catalogs channel.)"
+            )
 
     except subprocess.TimeoutExpired:
         return False, "Authentication timed out (5 minutes)"

--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -1278,7 +1278,7 @@ def ee_credentials_exist() -> bool:
 def authenticate_ee(
     progress_callback: Optional[Callable[[int, str], None]] = None,
 ) -> Tuple[bool, str]:
-    """Run ee.Authenticate() in the venv Python as a subprocess.
+    """Run ee.Authenticate() in an appropriate Python subprocess.
 
     This opens a browser window for the user to complete OAuth authentication.
     The subprocess is non-blocking — the user interacts with the browser, and
@@ -1290,11 +1290,19 @@ def authenticate_ee(
     Returns:
         A tuple of (success, message).
     """
-    if not venv_exists():
-        return False, "Virtual environment not found"
+    if venv_exists():
+        python_path = get_venv_python_path()
+        env = _get_clean_env_for_venv()
+    elif importlib.util.find_spec("ee") is not None:
+        python_path = sys.executable
+        env = os.environ.copy()
+    else:
+        return (
+            False,
+            "Virtual environment not found, and earthengine-api is not available "
+            "in the current QGIS Python. Install dependencies first.",
+        )
 
-    python_path = get_venv_python_path()
-    env = _get_clean_env_for_venv()
     kwargs = _get_subprocess_kwargs()
 
     # Bind the local OAuth callback on an ephemeral port to avoid collisions
@@ -1304,7 +1312,10 @@ def authenticate_ee(
     if progress_callback:
         progress_callback(50, "Waiting for browser authentication...")
 
-    _log("Running ee.Authenticate(auth_mode='localhost:0') in venv...")
+    _log(
+        "Running ee.Authenticate(auth_mode='localhost:0') "
+        f"with Python: {python_path}"
+    )
 
     try:
         result = subprocess.run(  # nosec B603

--- a/gee_data_catalogs/dialogs/deps_manager.py
+++ b/gee_data_catalogs/dialogs/deps_manager.py
@@ -87,3 +87,93 @@ class EEAuthWorker(QThread):
         except Exception as e:
             error_msg = f"{str(e)}\n{traceback.format_exc()}"
             self.finished.emit(False, error_msg)
+
+
+class EEInitWorker(QThread):
+    """Worker thread that initializes and verifies Earth Engine.
+
+    Runs ``core.ee_utils.initialize_ee`` and a small ``getInfo()`` round-trip
+    off the UI thread so QGIS does not freeze on slow networks.
+
+    Signals:
+        finished: Emitted with (success: bool, message: str) when done.
+    """
+
+    finished = pyqtSignal(bool, str)
+
+    def __init__(self, project, credentials_path=None, parent=None):
+        """Initialize the EE init worker.
+
+        Args:
+            project: Google Cloud project ID to pass through to Earth Engine.
+            credentials_path: Optional filesystem path to a service-account
+                JSON credentials file.
+            parent: Parent QObject.
+        """
+        super().__init__(parent)
+        self._project = project
+        self._credentials_path = credentials_path
+
+    def run(self):
+        """Initialize EE and verify with a getInfo round-trip."""
+        try:
+            credentials = None
+            if self._credentials_path:
+                try:
+                    from google.oauth2 import service_account
+                except ImportError:
+                    self.finished.emit(
+                        False,
+                        "Service-account credentials require the 'google-auth' "
+                        "package. Install it via Settings -> Dependencies, then "
+                        "retry.",
+                    )
+                    return
+                try:
+                    credentials = service_account.Credentials.from_service_account_file(
+                        self._credentials_path,
+                        scopes=["https://www.googleapis.com/auth/earthengine"],
+                    )
+                except Exception as exc:
+                    self.finished.emit(
+                        False,
+                        f"Failed to load credentials file: {exc}",
+                    )
+                    return
+
+            from ..core.ee_utils import get_last_init_error, initialize_ee
+
+            ok = initialize_ee(
+                project=self._project, force=True, credentials=credentials
+            )
+            if not ok:
+                self.finished.emit(
+                    False,
+                    get_last_init_error() or "Earth Engine initialization failed.",
+                )
+                return
+
+            try:
+                import ee
+            except ImportError:
+                self.finished.emit(False, "earthengine-api is not installed.")
+                return
+
+            try:
+                ee.Number(1).getInfo()
+            except Exception as exc:
+                project_desc = self._project or "(no project)"
+                self.finished.emit(
+                    False,
+                    "Initialize succeeded but a test request failed: "
+                    f"{exc}. Common causes: the Earth Engine API is not "
+                    f"enabled for project '{project_desc}', the account is "
+                    "not registered, or the credentials are missing the "
+                    "required scopes.",
+                )
+                return
+
+            self.finished.emit(True, "Earth Engine initialized & verified.")
+        except Exception as e:
+            error_msg = f"{str(e)}\n{traceback.format_exc()}"
+            self.finished.emit(False, error_msg)

--- a/gee_data_catalogs/dialogs/settings_dock.py
+++ b/gee_data_catalogs/dialogs/settings_dock.py
@@ -24,6 +24,8 @@ from qgis.PyQt.QtWidgets import (
     QFormLayout,
     QMessageBox,
     QTabWidget,
+    QFileDialog,
+    QProgressBar,
 )
 from qgis.PyQt.QtGui import QDesktopServices, QFont
 
@@ -36,6 +38,11 @@ from ..oauth import (
     clear_token_payload,
     store_token_payload,
 )
+
+try:
+    import ee
+except ImportError:
+    ee = None
 
 ENV_FALLBACKS = {
     "openai_api_key": ("OPENAI_API_KEY",),
@@ -129,6 +136,7 @@ class OAuthRefreshWorker(QThread):
 class SettingsDockWidget(QDockWidget):
     """A settings panel for configuring plugin options."""
 
+    auth_succeeded = pyqtSignal()
     settings_saved = pyqtSignal()
 
     # Settings keys
@@ -144,6 +152,7 @@ class SettingsDockWidget(QDockWidget):
         super().__init__("GEE Data Catalogs Settings", parent)
         self.iface = iface
         self.settings = QSettings()
+        self._auth_worker = None
         self._oauth_worker = None
         self._env_sourced_credentials = {}
 
@@ -307,7 +316,39 @@ class SettingsDockWidget(QDockWidget):
         info_label.setWordWrap(True)
         project_layout.addRow("", info_label)
 
+        cred_layout = QHBoxLayout()
+        self.credentials_input = QLineEdit()
+        self.credentials_input.setPlaceholderText("Optional path to credentials JSON")
+        cred_layout.addWidget(self.credentials_input)
+        self.browse_cred_btn = QPushButton("...")
+        self.browse_cred_btn.setMaximumWidth(30)
+        self.browse_cred_btn.clicked.connect(self._browse_credentials)
+        cred_layout.addWidget(self.browse_cred_btn)
+        project_layout.addRow("Credentials:", cred_layout)
+
         layout.addWidget(project_group)
+
+        actions_group = QGroupBox("Actions")
+        actions_layout = QVBoxLayout(actions_group)
+
+        auth_btn = QPushButton("Authenticate (opens browser)")
+        auth_btn.clicked.connect(self._authenticate_ee)
+        actions_layout.addWidget(auth_btn)
+
+        init_btn = QPushButton("Initialize Earth Engine")
+        init_btn.clicked.connect(self._initialize_ee)
+        actions_layout.addWidget(init_btn)
+
+        self.ee_status_label = QLabel("Status: Not initialized")
+        self.ee_status_label.setStyleSheet("color: gray;")
+        self.ee_status_label.setWordWrap(True)
+        actions_layout.addWidget(self.ee_status_label)
+
+        self.ee_progress_bar = QProgressBar()
+        self.ee_progress_bar.setVisible(False)
+        actions_layout.addWidget(self.ee_progress_bar)
+
+        layout.addWidget(actions_group)
 
         # Default filters
         filters_group = QGroupBox("Default Filters")
@@ -520,6 +561,148 @@ class SettingsDockWidget(QDockWidget):
         layout.addStretch()
         return widget
 
+    def _browse_credentials(self):
+        """Open file browser for an optional credentials JSON file."""
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select Credentials File",
+            "",
+            "JSON Files (*.json);;All Files (*)",
+        )
+        if file_path:
+            self.credentials_input.setText(file_path)
+
+    def _get_ee_module(self):
+        """Return the Earth Engine module, re-importing after installs if needed."""
+        global ee
+        if ee is None:
+            try:
+                import ee as _ee
+
+                ee = _ee
+            except ImportError:
+                return None
+        return ee
+
+    def _initialize_ee(self):
+        """Initialize and verify Earth Engine with current settings."""
+        ee_module = self._get_ee_module()
+        if ee_module is None:
+            QMessageBox.warning(
+                self,
+                "Warning",
+                "Earth Engine API not installed.\n\nPlease install earthengine-api.",
+            )
+            return
+
+        project = self.ee_project_input.text().strip()
+        if not project:
+            project = os.environ.get("EE_PROJECT_ID", "")
+
+        if not project:
+            QMessageBox.warning(
+                self,
+                "Project ID Required",
+                "A Google Cloud project ID is required to initialize "
+                "Earth Engine.\n\nPlease enter your project ID above.",
+            )
+            self.ee_project_input.setFocus()
+            return
+
+        try:
+            cred_file = self.credentials_input.text().strip()
+            credentials = None
+
+            if cred_file:
+                from google.oauth2 import service_account
+
+                credentials = service_account.Credentials.from_service_account_file(
+                    cred_file,
+                    scopes=["https://www.googleapis.com/auth/earthengine"],
+                )
+
+            if credentials is not None:
+                ee_module.Initialize(credentials=credentials, project=project)
+            else:
+                ee_module.Initialize(project=project)
+        except Exception as e:
+            self.ee_status_label.setText("Status: Error")
+            self.ee_status_label.setStyleSheet("color: red;")
+            QMessageBox.critical(
+                self,
+                "Initialization Error",
+                f"Failed to initialize Earth Engine:\n\n{str(e)}",
+            )
+            return
+
+        try:
+            ee_module.Number(1).getInfo()
+        except Exception as e:
+            self.ee_status_label.setText("Status: Error")
+            self.ee_status_label.setStyleSheet("color: red;")
+            QMessageBox.critical(
+                self,
+                "Earth Engine Verification Failed",
+                "Initialize succeeded but a test request failed:\n\n"
+                f"{str(e)}\n\n"
+                "Common causes: the Earth Engine API is not enabled for "
+                f"project '{project}', the account is not registered, or "
+                "the credentials are missing the required scopes.",
+            )
+            return
+
+        from ..core.ee_utils import mark_ee_initialized
+
+        mark_ee_initialized(True)
+
+        self.ee_status_label.setText("Status: Initialized & verified")
+        self.ee_status_label.setStyleSheet("color: green; font-weight: bold;")
+        self.iface.messageBar().pushSuccess(
+            "GEE Data Catalogs", "Earth Engine initialized successfully!"
+        )
+
+    def _authenticate_ee(self):
+        """Start Earth Engine authentication in the background."""
+        from .deps_manager import EEAuthWorker
+
+        if self._auth_worker is not None and self._auth_worker.isRunning():
+            return
+
+        self.ee_status_label.setText(
+            "Authenticating... A browser window should open.\n"
+            "Complete the sign-in and return here."
+        )
+        self.ee_status_label.setStyleSheet("color: blue;")
+        self.ee_progress_bar.setVisible(True)
+        self.ee_progress_bar.setRange(0, 0)
+
+        self._auth_worker = EEAuthWorker()
+        self._auth_worker.progress.connect(self._on_auth_progress)
+        self._auth_worker.finished.connect(self._on_auth_finished)
+        self._auth_worker.start()
+
+    def _on_auth_progress(self, percent: int, message: str):
+        """Handle Earth Engine auth progress updates."""
+        self.ee_status_label.setText(message)
+
+    def _on_auth_finished(self, success: bool, message: str):
+        """Handle Earth Engine authentication completion."""
+        self._auth_worker = None
+        self.ee_progress_bar.setVisible(False)
+        self.ee_progress_bar.setRange(0, 100)
+
+        if success:
+            self.ee_status_label.setText("Status: Credentials found")
+            self.ee_status_label.setStyleSheet("color: green; font-weight: bold;")
+            self.iface.messageBar().pushSuccess(
+                "GEE Data Catalogs",
+                "Earth Engine authenticated successfully!",
+            )
+            self.auth_succeeded.emit()
+        else:
+            self.ee_status_label.setText(f"Authentication failed: {message[:150]}")
+            self.ee_status_label.setStyleSheet("color: red;")
+
     def _oauth_config(self):
         """Return the built-in ChatGPT/Codex login settings."""
         config = dict(CODEX_DEFAULT_CONFIG)
@@ -679,6 +862,9 @@ class SettingsDockWidget(QDockWidget):
         self.ee_project_input.setText(
             self.settings.value(f"{self.SETTINGS_PREFIX}ee_project", "", type=str)
         )
+        self.credentials_input.setText(
+            self.settings.value(f"{self.SETTINGS_PREFIX}credentials", "", type=str)
+        )
         self.default_cloud_cover.setValue(
             self.settings.value(
                 f"{self.SETTINGS_PREFIX}default_cloud_cover", 20, type=int
@@ -773,6 +959,9 @@ class SettingsDockWidget(QDockWidget):
             f"{self.SETTINGS_PREFIX}ee_project", self.ee_project_input.text()
         )
         self.settings.setValue(
+            f"{self.SETTINGS_PREFIX}credentials", self.credentials_input.text()
+        )
+        self.settings.setValue(
             f"{self.SETTINGS_PREFIX}default_cloud_cover",
             self.default_cloud_cover.value(),
         )
@@ -860,6 +1049,7 @@ class SettingsDockWidget(QDockWidget):
 
         # Earth Engine
         self.ee_project_input.clear()
+        self.credentials_input.clear()
         self.default_cloud_cover.setValue(20)
         self.default_date_range.setValue(365)
         self.max_features.setValue(5000)

--- a/gee_data_catalogs/dialogs/settings_dock.py
+++ b/gee_data_catalogs/dialogs/settings_dock.py
@@ -153,6 +153,7 @@ class SettingsDockWidget(QDockWidget):
         self.iface = iface
         self.settings = QSettings()
         self._auth_worker = None
+        self._init_worker = None
         self._oauth_worker = None
         self._env_sourced_credentials = {}
 
@@ -609,56 +610,42 @@ class SettingsDockWidget(QDockWidget):
             self.ee_project_input.setFocus()
             return
 
-        try:
-            cred_file = self.credentials_input.text().strip()
-            credentials = None
+        from .deps_manager import EEInitWorker
 
-            if cred_file:
-                from google.oauth2 import service_account
+        if self._init_worker is not None and self._init_worker.isRunning():
+            return
 
-                credentials = service_account.Credentials.from_service_account_file(
-                    cred_file,
-                    scopes=["https://www.googleapis.com/auth/earthengine"],
-                )
+        cred_file = self.credentials_input.text().strip() or None
 
-            if credentials is not None:
-                ee_module.Initialize(credentials=credentials, project=project)
-            else:
-                ee_module.Initialize(project=project)
-        except Exception as e:
-            self.ee_status_label.setText("Status: Error")
-            self.ee_status_label.setStyleSheet("color: red;")
-            QMessageBox.critical(
-                self,
-                "Initialization Error",
-                f"Failed to initialize Earth Engine:\n\n{str(e)}",
+        self.ee_status_label.setText("Initializing & verifying Earth Engine...")
+        self.ee_status_label.setStyleSheet("color: blue;")
+        self.ee_progress_bar.setVisible(True)
+        self.ee_progress_bar.setRange(0, 0)
+
+        self._init_worker = EEInitWorker(project=project, credentials_path=cred_file)
+        self._init_worker.finished.connect(self._on_init_finished)
+        self._init_worker.start()
+
+    def _on_init_finished(self, success: bool, message: str):
+        """Handle EEInitWorker completion."""
+        self._init_worker = None
+        self.ee_progress_bar.setVisible(False)
+        self.ee_progress_bar.setRange(0, 100)
+
+        if success:
+            self.ee_status_label.setText("Status: Initialized & verified")
+            self.ee_status_label.setStyleSheet("color: green; font-weight: bold;")
+            self.iface.messageBar().pushSuccess(
+                "GEE Data Catalogs", "Earth Engine initialized successfully!"
             )
             return
 
-        try:
-            ee_module.Number(1).getInfo()
-        except Exception as e:
-            self.ee_status_label.setText("Status: Error")
-            self.ee_status_label.setStyleSheet("color: red;")
-            QMessageBox.critical(
-                self,
-                "Earth Engine Verification Failed",
-                "Initialize succeeded but a test request failed:\n\n"
-                f"{str(e)}\n\n"
-                "Common causes: the Earth Engine API is not enabled for "
-                f"project '{project}', the account is not registered, or "
-                "the credentials are missing the required scopes.",
-            )
-            return
-
-        from ..core.ee_utils import mark_ee_initialized
-
-        mark_ee_initialized(True)
-
-        self.ee_status_label.setText("Status: Initialized & verified")
-        self.ee_status_label.setStyleSheet("color: green; font-weight: bold;")
-        self.iface.messageBar().pushSuccess(
-            "GEE Data Catalogs", "Earth Engine initialized successfully!"
+        self.ee_status_label.setText("Status: Error")
+        self.ee_status_label.setStyleSheet("color: red;")
+        QMessageBox.critical(
+            self,
+            "Earth Engine Initialization Failed",
+            message or "Earth Engine initialization failed.",
         )
 
     def _authenticate_ee(self):

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -326,7 +326,11 @@ class GeeDataCatalogs:
         """Try to auto-initialize Earth Engine if EE_PROJECT_ID is set."""
         try:
             from qgis.PyQt.QtCore import QSettings
-            from .core.ee_utils import initialize_ee, is_ee_initialized
+            from .core.ee_utils import (
+                get_last_init_error,
+                initialize_ee,
+                is_ee_initialized,
+            )
 
             # Check if already initialized
             if is_ee_initialized():
@@ -353,20 +357,16 @@ class GeeDataCatalogs:
 
             # Only try to initialize if we have a project ID
             if project_id:
-                try:
-                    from qgis.core import QgsMessageLog, Qgis
+                from qgis.core import QgsMessageLog, Qgis
 
+                QgsMessageLog.logMessage(
+                    f"Auto-initializing Earth Engine with project from {project_source}: {project_id}",
+                    "GEE Data Catalogs",
+                    Qgis.MessageLevel.Info,
+                )
+                if not initialize_ee(project=project_id):
                     QgsMessageLog.logMessage(
-                        f"Auto-initializing Earth Engine with project from {project_source}: {project_id}",
-                        "GEE Data Catalogs",
-                        Qgis.MessageLevel.Info,
-                    )
-                    initialize_ee(project=project_id)
-                except Exception as exc:
-                    from qgis.core import QgsMessageLog, Qgis
-
-                    QgsMessageLog.logMessage(
-                        f"Auto-init EE failed: {exc}",
+                        f"Auto-init EE failed: {get_last_init_error()}",
                         "GEE Data Catalogs",
                         Qgis.MessageLevel.Warning,
                     )
@@ -520,7 +520,7 @@ class GeeDataCatalogs:
         """Perform the actual EE initialization after dependencies are ready."""
         try:
             from qgis.PyQt.QtCore import QSettings
-            from .core.ee_utils import initialize_ee
+            from .core.ee_utils import initialize_ee, get_last_init_error
 
             # Read project ID from settings
             settings = QSettings()
@@ -541,8 +541,19 @@ class GeeDataCatalogs:
                 if project_id:
                     project_source = "EE_PROJECT_ID environment variable"
 
-            # Initialize with project ID
-            initialize_ee(project=project_id if project_id else None)
+            if not initialize_ee(
+                project=project_id if project_id else None, force=True
+            ):
+                detail = get_last_init_error() or (
+                    "Earth Engine initialization failed for an unknown reason."
+                )
+                QMessageBox.critical(
+                    self.iface.mainWindow(),
+                    "Earth Engine Initialization Failed",
+                    f"Failed to initialize Earth Engine:\n\n{detail}",
+                )
+                self._show_settings_ee_tab()
+                return
 
             success_msg = "Earth Engine initialized successfully!"
             if project_source:
@@ -706,6 +717,7 @@ class GeeDataCatalogs:
             self._settings_dock.visibilityChanged.connect(
                 self._on_settings_visibility_changed
             )
+            self._settings_dock.auth_succeeded.connect(self._on_auth_completed)
             self._settings_dock.settings_saved.connect(self._try_auto_init_ee)
             self.iface.addDockWidget(
                 Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
@@ -731,7 +743,7 @@ class GeeDataCatalogs:
             self._settings_dock.show_ee_tab()
             self.iface.messageBar().pushInfo(
                 "GEE Data Catalogs",
-                "Please enter your Google Cloud project ID and click Save Settings.",
+                "Authenticate, enter your Google Cloud project ID, then initialize Earth Engine.",
             )
 
     def _on_settings_visibility_changed(self, visible):

--- a/tests/test_initialize_ee_errors.py
+++ b/tests/test_initialize_ee_errors.py
@@ -1,0 +1,155 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EE_UTILS_PATH = REPO_ROOT / "gee_data_catalogs" / "core" / "ee_utils.py"
+
+
+def _install_qgis_stubs(monkeypatch, settings_store=None):
+    settings_store = settings_store if settings_store is not None else {}
+
+    class FakeQSettings:
+        def value(self, key, default=None, type=None):
+            value = settings_store.get(key, default)
+            if type is not None and value is not None:
+                try:
+                    return type(value)
+                except Exception:
+                    return value
+            return value
+
+    class FakeQgsProject:
+        @classmethod
+        def instance(cls):
+            return cls()
+
+    class FakeQgsMessageLog:
+        @staticmethod
+        def logMessage(*args, **kwargs):
+            return None
+
+    fake_qgis = types.ModuleType("qgis")
+    fake_qgis_core = types.ModuleType("qgis.core")
+    fake_qgis_core.QgsProject = FakeQgsProject
+    fake_qgis_core.QgsRasterLayer = type("QgsRasterLayer", (), {})
+    fake_qgis_core.QgsMessageLog = FakeQgsMessageLog
+    fake_qgis_core.Qgis = types.SimpleNamespace(
+        Info=1,
+        Warning=2,
+        MessageLevel=types.SimpleNamespace(Info=1, Warning=2, Success=3),
+    )
+
+    fake_pyqt = types.ModuleType("qgis.PyQt")
+    fake_qtcore = types.ModuleType("qgis.PyQt.QtCore")
+    fake_qtcore.QSettings = FakeQSettings
+
+    monkeypatch.setitem(sys.modules, "qgis", fake_qgis)
+    monkeypatch.setitem(sys.modules, "qgis.core", fake_qgis_core)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt", fake_pyqt)
+    monkeypatch.setitem(sys.modules, "qgis.PyQt.QtCore", fake_qtcore)
+
+
+def _load_ee_utils(monkeypatch, fake_ee, settings_store=None):
+    _install_qgis_stubs(monkeypatch, settings_store=settings_store)
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+
+    module_name = "ee_utils_under_test"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, EE_UTILS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_initialize_failure_preserves_error_and_does_not_authenticate(monkeypatch):
+    def initialize(*args, **kwargs):
+        raise RuntimeError("project does not have Earth Engine API enabled")
+
+    def authenticate(*args, **kwargs):
+        raise AssertionError("initialize_ee must not call ee.Authenticate()")
+
+    fake_ee = types.SimpleNamespace(Initialize=initialize, Authenticate=authenticate)
+    ee_utils = _load_ee_utils(monkeypatch, fake_ee)
+    monkeypatch.setattr(ee_utils, "_check_credentials_exist", lambda: True)
+
+    assert ee_utils.initialize_ee(project="bad-project") is False
+    assert "project does not have Earth Engine API enabled" in (
+        ee_utils.get_last_init_error() or ""
+    )
+
+
+def test_initialize_does_not_pass_credentials_kwarg(monkeypatch):
+    received_kwargs = {}
+
+    def initialize(*args, **kwargs):
+        received_kwargs.update(kwargs)
+
+    fake_ee = types.SimpleNamespace(
+        Initialize=initialize,
+        data=types.SimpleNamespace(
+            getUserAgent=lambda: "old-agent",
+            setUserAgent=lambda value: None,
+        ),
+    )
+    ee_utils = _load_ee_utils(monkeypatch, fake_ee)
+    monkeypatch.setattr(ee_utils, "_check_credentials_exist", lambda: True)
+
+    assert ee_utils.initialize_ee(project="my-project") is True
+    assert received_kwargs == {"project": "my-project"}
+    assert "credentials" not in received_kwargs
+
+
+def test_project_lookup_prefers_explicit_then_settings_then_env(monkeypatch):
+    projects = []
+
+    def initialize(*args, **kwargs):
+        projects.append(kwargs.get("project"))
+
+    fake_ee = types.SimpleNamespace(
+        Initialize=initialize,
+        data=types.SimpleNamespace(
+            getUserAgent=lambda: "old-agent",
+            setUserAgent=lambda value: None,
+        ),
+    )
+    settings_store = {"GeeDataCatalogs/ee_project": "settings-project"}
+    ee_utils = _load_ee_utils(monkeypatch, fake_ee, settings_store=settings_store)
+    monkeypatch.setattr(ee_utils, "_check_credentials_exist", lambda: True)
+
+    assert ee_utils.initialize_ee(project="explicit-project", force=True) is True
+    ee_utils.mark_ee_initialized(False)
+
+    assert ee_utils.initialize_ee(force=True) is True
+    ee_utils.mark_ee_initialized(False)
+
+    settings_store.clear()
+    monkeypatch.setenv("EE_PROJECT_ID", "env-project")
+    assert ee_utils.initialize_ee(force=True) is True
+
+    assert projects == ["explicit-project", "settings-project", "env-project"]
+
+
+def test_mark_initialized_clears_last_init_error(monkeypatch):
+    def initialize(*args, **kwargs):
+        raise RuntimeError("refresh token expired")
+
+    fake_ee = types.SimpleNamespace(
+        Initialize=initialize,
+        data=types.SimpleNamespace(
+            getUserAgent=lambda: "old-agent",
+            setUserAgent=lambda value: None,
+        ),
+    )
+    ee_utils = _load_ee_utils(monkeypatch, fake_ee)
+    monkeypatch.setattr(ee_utils, "_check_credentials_exist", lambda: True)
+
+    assert ee_utils.initialize_ee(project="bad-project", force=True) is False
+    assert "refresh token expired" in (ee_utils.get_last_init_error() or "")
+
+    ee_utils.mark_ee_initialized(True)
+
+    assert ee_utils.is_ee_initialized() is True
+    assert ee_utils.get_last_init_error() is None

--- a/tests/test_venv_manager_auth.py
+++ b/tests/test_venv_manager_auth.py
@@ -1,0 +1,38 @@
+import sys
+import types
+
+from gee_data_catalogs.core import venv_manager
+
+
+def test_authenticate_ee_falls_back_to_current_python(monkeypatch):
+    calls = {}
+
+    def fake_run(cmd, capture_output, text, timeout, env, **kwargs):
+        calls["cmd"] = cmd
+        calls["env"] = env
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda: False)
+    monkeypatch.setattr(
+        venv_manager.importlib.util,
+        "find_spec",
+        lambda name: object() if name == "ee" else None,
+    )
+    monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
+
+    success, message = venv_manager.authenticate_ee()
+
+    assert success is True
+    assert "completed successfully" in message
+    assert calls["cmd"][0] == sys.executable
+    assert "PYTHONPATH" in calls["env"] or isinstance(calls["env"], dict)
+
+
+def test_authenticate_ee_reports_missing_envs(monkeypatch):
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda: False)
+    monkeypatch.setattr(venv_manager.importlib.util, "find_spec", lambda name: None)
+
+    success, message = venv_manager.authenticate_ee()
+
+    assert success is False
+    assert "Virtual environment not found" in message


### PR DESCRIPTION
## Summary
- Replace exception-raising `initialize_ee` with a return-False path that records the last error, so the UI can show real failure reasons instead of swallowed exceptions.
- Add Authenticate and Initialize buttons (plus an optional service-account credentials picker and status/progress indicators) to the Earth Engine settings tab.
- Read the EE project ID from plugin settings first then `EE_PROJECT_ID`, and bind `ee.Authenticate` to an ephemeral localhost port to avoid collisions.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `pytest tests/test_initialize_ee_errors.py`
- [ ] In QGIS, open Settings -> Earth Engine, click Authenticate, complete browser flow, then Initialize and verify the success banner.
- [ ] Enter a bad project ID, click Initialize, and confirm the error dialog shows the underlying EE message.