### PR TITLE
feat(ai): delegate AI Assistant to OpenGeoAgent plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A comprehensive QGIS plugin for browsing, searching, and loading Google Earth En
 - **Conversion**: Convert Earth Engine JavaScript API to Python API
 - **Inspector**: Inspect Earth Engine layer values at specific locations
 - **Export**: Export Earth Engine layers to various file formats
-- **AI Assistant**: Ask GeoAgent about Earth Engine datasets and QGIS map actions, with streaming output enabled by default
+- **AI Assistant**: Open the OpenGeoAgent chat panel for Earth Engine dataset and QGIS map assistance
 - **Multiple Data Types**: Load EE Image, ImageCollection, and FeatureCollection layers
 - **Integration**: Works seamlessly with [qgis-geemap-plugin](https://github.com/opengeos/qgis-geemap-plugin)
 - **Update Checker**: Built-in plugin update checker from GitHub

--- a/gee_data_catalogs/dialogs/catalog_dock.py
+++ b/gee_data_catalogs/dialogs/catalog_dock.py
@@ -2575,14 +2575,6 @@ class CatalogDockWidget(QDockWidget):
         self.export_tab = self._create_export_tab()
         self.tab_widget.addTab(self.export_tab, "Export")
 
-        # AI assistant tab
-        from .chat_dock import ChatPanelWidget
-
-        self.ai_assistant_tab = ChatPanelWidget(
-            self.iface, plugin=self.plugin, parent=self
-        )
-        self.tab_widget.addTab(self.ai_assistant_tab, "AI Assistant")
-
         # Progress bar
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
@@ -5581,10 +5573,10 @@ class CatalogDockWidget(QDockWidget):
             plugin._sync_panel_actions()
 
     def show_ai_assistant_tab(self):
-        """Show the AI assistant inside the main catalog panel."""
-        self.tab_widget.setCurrentWidget(self.ai_assistant_tab)
-        self.show()
-        self.raise_()
+        """Backward-compatible entry point for opening OpenGeoAgent chat."""
+        plugin = getattr(self, "plugin", None)
+        if plugin is not None and hasattr(plugin, "open_ai_assistant"):
+            plugin.open_ai_assistant()
 
     def _toggle_image_selection(self, checked):
         """Toggle visibility of image selection widgets."""
@@ -8981,10 +8973,5 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         if self._timeseries_thread and self._timeseries_thread.isRunning():
             self._timeseries_thread.terminate()
             self._timeseries_thread.wait()
-
-        # Stop and wait for the AI assistant chat worker before deletion
-        ai_tab = getattr(self, "ai_assistant_tab", None)
-        if ai_tab is not None and hasattr(ai_tab, "shutdown"):
-            ai_tab.shutdown()
 
         event.accept()

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -6,11 +6,14 @@ integration, menu items, toolbar buttons, and dockable panels.
 """
 
 import os
+import sys
 
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QMenu, QToolBar, QMessageBox
 from qgis.core import QgsProject
+
+OPEN_GEOAGENT_PLUGIN_CANDIDATES = ("open_geoagent",)
 
 
 class GeeDataCatalogs:
@@ -143,9 +146,8 @@ class GeeDataCatalogs:
         self.chat_action = self.add_action(
             robot_icon,
             "AI Assistant",
-            self.toggle_chat_dock,
-            status_tip="Open the AI Assistant tab in the GEE Data Catalogs panel",
-            checkable=True,
+            self.open_ai_assistant,
+            status_tip="Open the OpenGeoAgent chat panel",
             parent=self.iface.mainWindow(),
         )
 
@@ -205,9 +207,6 @@ class GeeDataCatalogs:
 
         # Remove dock widgets
         if self._catalog_dock:
-            ai_tab = getattr(self._catalog_dock, "ai_assistant_tab", None)
-            if ai_tab is not None and hasattr(ai_tab, "shutdown"):
-                ai_tab.shutdown()
             self.iface.removeDockWidget(self._catalog_dock)
             self._catalog_dock.deleteLater()
             self._catalog_dock = None
@@ -645,30 +644,133 @@ class GeeDataCatalogs:
         """Handle Catalog dock visibility change."""
         self._sync_panel_actions()
 
-    def toggle_chat_dock(self):
-        """Toggle the AI assistant tab in the main Catalog panel."""
-        if self._catalog_dock is not None and self._catalog_dock.isVisible():
-            current_tab = self._catalog_dock.tab_widget.currentWidget()
-            if current_tab == self._catalog_dock.ai_assistant_tab:
-                self._catalog_dock.hide()
-                return
-            self._catalog_dock.show_ai_assistant_tab()
-            self._sync_panel_actions()
+    def open_ai_assistant(self):
+        """Open the OpenGeoAgent chat panel, or prompt for plugin installation."""
+        plugin = self._get_open_geoagent_plugin()
+        if plugin is None:
+            self._prompt_open_geoagent_install()
             return
 
-        self._ensure_dependencies(self._show_ai_assistant_tab)
+        if not hasattr(plugin, "toggle_chat_dock"):
+            QMessageBox.warning(
+                self.iface.mainWindow(),
+                "OpenGeoAgent Required",
+                "OpenGeoAgent is installed, but this version does not expose "
+                "the chat panel launcher expected by GEE Data Catalogs.\n\n"
+                "Please update OpenGeoAgent and try again.",
+            )
+            return
 
-    def _show_ai_assistant_tab(self):
-        """Create/show the main panel and switch to the AI assistant tab."""
-        if self._catalog_dock is None:
-            self._create_catalog_dock()
-        if self._catalog_dock is not None:
-            self._catalog_dock.show_ai_assistant_tab()
-        self._sync_panel_actions()
+        try:
+            chat_dock = getattr(plugin, "_chat_dock", None)
+            if chat_dock is not None and chat_dock.isVisible():
+                chat_dock.show()
+                chat_dock.raise_()
+                return
+
+            plugin.toggle_chat_dock()
+        except Exception as exc:
+            QMessageBox.critical(
+                self.iface.mainWindow(),
+                "OpenGeoAgent",
+                f"Failed to open the OpenGeoAgent chat panel:\n{exc}",
+            )
+
+    def _get_open_geoagent_plugin(self):
+        """Return the loaded OpenGeoAgent plugin instance, loading it if possible."""
+        try:
+            import qgis.utils as qgis_utils
+        except Exception as exc:
+            print(
+                f"GEE Data Catalogs: could not import qgis.utils: {exc}",
+                file=sys.stderr,
+            )
+            return None
+
+        plugins = getattr(qgis_utils, "plugins", {}) or {}
+        for package_name in OPEN_GEOAGENT_PLUGIN_CANDIDATES:
+            plugin = plugins.get(package_name)
+            if plugin is not None:
+                return plugin
+
+        available = set(getattr(qgis_utils, "available_plugins", []) or [])
+        for package_name in OPEN_GEOAGENT_PLUGIN_CANDIDATES:
+            if package_name not in available:
+                continue
+
+            try:
+                load_plugin = getattr(qgis_utils, "loadPlugin", None)
+                if callable(load_plugin) and package_name not in plugins:
+                    load_plugin(package_name)
+
+                start_plugin = getattr(qgis_utils, "startPlugin", None)
+                active_plugins = getattr(qgis_utils, "active_plugins", []) or []
+                if callable(start_plugin) and package_name not in active_plugins:
+                    start_plugin(package_name)
+
+                plugins = getattr(qgis_utils, "plugins", {}) or {}
+                plugin = plugins.get(package_name)
+                if plugin is not None:
+                    return plugin
+            except Exception as exc:
+                print(
+                    f"GEE Data Catalogs: failed to load OpenGeoAgent plugin "
+                    f"'{package_name}': {exc}",
+                    file=sys.stderr,
+                )
+
+        return None
+
+    def _prompt_open_geoagent_install(self):
+        """Tell the user how to install OpenGeoAgent from the QGIS Plugin Manager."""
+        message = (
+            "The AI Assistant is provided by the OpenGeoAgent QGIS plugin.\n\n"
+            "Install it from the QGIS Plugin Manager:\n"
+            "  Plugins > Manage and Install Plugins... > All\n"
+            "  Search for 'OpenGeoAgent' and click Install Plugin.\n\n"
+            "After installing (or enabling) OpenGeoAgent, click the AI "
+            "Assistant button again."
+        )
+        box = QMessageBox(self.iface.mainWindow())
+        box.setIcon(QMessageBox.Icon.Information)
+        box.setWindowTitle("Install OpenGeoAgent")
+        box.setText(message)
+        manager_button = box.addButton(
+            "Open Plugin Manager", QMessageBox.ButtonRole.ActionRole
+        )
+        box.addButton(QMessageBox.StandardButton.Ok)
+        box.exec()
+
+        if box.clickedButton() == manager_button:
+            self._open_qgis_plugin_manager()
+
+    def _open_qgis_plugin_manager(self):
+        """Open the QGIS Plugin Manager dialog."""
+        try:
+            action = self.iface.actionManagePlugins()
+            if action is not None:
+                action.trigger()
+                return
+        except Exception as exc:
+            print(
+                f"GEE Data Catalogs: could not open QGIS Plugin Manager: {exc}",
+                file=sys.stderr,
+            )
+
+        QMessageBox.information(
+            self.iface.mainWindow(),
+            "Open Plugin Manager",
+            "Open the QGIS Plugin Manager from the menu:\n"
+            "Plugins > Manage and Install Plugins...",
+        )
+
+    def toggle_chat_dock(self):
+        """Backward-compatible entry point for opening OpenGeoAgent chat."""
+        self.open_ai_assistant()
 
     def _create_chat_dock(self):
-        """Backward-compatible entry point for opening the assistant tab."""
-        self._show_ai_assistant_tab()
+        """Backward-compatible entry point for opening OpenGeoAgent chat."""
+        self.open_ai_assistant()
 
     def _on_chat_visibility_changed(self, visible):
         """Handle AI assistant dock visibility change."""
@@ -682,14 +784,8 @@ class GeeDataCatalogs:
         if hasattr(self, "catalog_action"):
             self.catalog_action.setChecked(catalog_visible)
 
-        assistant_visible = False
-        if catalog_visible and hasattr(self._catalog_dock, "ai_assistant_tab"):
-            assistant_visible = (
-                self._catalog_dock.tab_widget.currentWidget()
-                == self._catalog_dock.ai_assistant_tab
-            )
         if hasattr(self, "chat_action"):
-            self.chat_action.setChecked(assistant_visible)
+            self.chat_action.setChecked(False)
 
     def toggle_settings_dock(self):
         """Toggle the Settings dock widget visibility (with dependency gate)."""

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -6,7 +6,6 @@ integration, menu items, toolbar buttons, and dockable panels.
 """
 
 import os
-import sys
 
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon
@@ -681,9 +680,12 @@ class GeeDataCatalogs:
         try:
             import qgis.utils as qgis_utils
         except Exception as exc:
-            print(
-                f"GEE Data Catalogs: could not import qgis.utils: {exc}",
-                file=sys.stderr,
+            from qgis.core import QgsMessageLog, Qgis
+
+            QgsMessageLog.logMessage(
+                f"Could not import qgis.utils: {exc}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
             )
             return None
 
@@ -713,10 +715,12 @@ class GeeDataCatalogs:
                 if plugin is not None:
                     return plugin
             except Exception as exc:
-                print(
-                    f"GEE Data Catalogs: failed to load OpenGeoAgent plugin "
-                    f"'{package_name}': {exc}",
-                    file=sys.stderr,
+                from qgis.core import QgsMessageLog, Qgis
+
+                QgsMessageLog.logMessage(
+                    f"Failed to load OpenGeoAgent plugin " f"'{package_name}': {exc}",
+                    "GEE Data Catalogs",
+                    Qgis.MessageLevel.Warning,
                 )
 
         return None
@@ -752,9 +756,12 @@ class GeeDataCatalogs:
                 action.trigger()
                 return
         except Exception as exc:
-            print(
-                f"GEE Data Catalogs: could not open QGIS Plugin Manager: {exc}",
-                file=sys.stderr,
+            from qgis.core import QgsMessageLog, Qgis
+
+            QgsMessageLog.logMessage(
+                f"Could not open QGIS Plugin Manager: {exc}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
             )
 
         QMessageBox.information(
@@ -783,9 +790,6 @@ class GeeDataCatalogs:
         )
         if hasattr(self, "catalog_action"):
             self.catalog_action.setChecked(catalog_visible)
-
-        if hasattr(self, "chat_action"):
-            self.chat_action.setChecked(False)
 
     def toggle_settings_dock(self):
         """Toggle the Settings dock widget visibility (with dependency gate)."""

--- a/gee_data_catalogs/metadata.txt
+++ b/gee_data_catalogs/metadata.txt
@@ -3,7 +3,7 @@ name=Earth Engine Data Catalogs
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Browse, search, and load Google Earth Engine data catalogs directly in QGIS.
-version=0.11.1
+version=0.12.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -37,6 +37,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.12.0
+        - Route the AI Assistant button to the OpenGeoAgent chat panel
     0.11.1
         - Fixed dependency installer Python detection for macOS QGIS app bundles
     0.11.0

--- a/tests/test_open_geoagent_launcher.py
+++ b/tests/test_open_geoagent_launcher.py
@@ -30,6 +30,19 @@ def test_ai_assistant_button_raises_visible_open_geoagent_chat(monkeypatch):
     plugin.toggle_chat_dock.assert_not_called()
 
 
+def test_ai_assistant_button_prompts_install_when_open_geoagent_missing(monkeypatch):
+    monkeypatch.setattr(qgis_utils, "plugins", {}, raising=False)
+    monkeypatch.setattr(qgis_utils, "available_plugins", [], raising=False)
+
+    plugin = GeeDataCatalogs(MagicMock())
+    prompt = MagicMock()
+    monkeypatch.setattr(plugin, "_prompt_open_geoagent_install", prompt)
+
+    plugin.open_ai_assistant()
+
+    prompt.assert_called_once_with()
+
+
 def test_ai_assistant_button_loads_available_open_geoagent(monkeypatch):
     plugin = SimpleNamespace(toggle_chat_dock=MagicMock(), _chat_dock=None)
 

--- a/tests/test_open_geoagent_launcher.py
+++ b/tests/test_open_geoagent_launcher.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import qgis.utils as qgis_utils
+
+from gee_data_catalogs.gee_data_catalogs import GeeDataCatalogs
+
+
+def test_ai_assistant_button_opens_loaded_open_geoagent(monkeypatch):
+    plugin = SimpleNamespace(toggle_chat_dock=MagicMock(), _chat_dock=None)
+    monkeypatch.setattr(qgis_utils, "plugins", {"open_geoagent": plugin}, raising=False)
+    monkeypatch.setattr(qgis_utils, "available_plugins", [], raising=False)
+
+    GeeDataCatalogs(MagicMock()).open_ai_assistant()
+
+    plugin.toggle_chat_dock.assert_called_once_with()
+
+
+def test_ai_assistant_button_raises_visible_open_geoagent_chat(monkeypatch):
+    dock = MagicMock()
+    dock.isVisible.return_value = True
+    plugin = SimpleNamespace(toggle_chat_dock=MagicMock(), _chat_dock=dock)
+    monkeypatch.setattr(qgis_utils, "plugins", {"open_geoagent": plugin}, raising=False)
+    monkeypatch.setattr(qgis_utils, "available_plugins", [], raising=False)
+
+    GeeDataCatalogs(MagicMock()).open_ai_assistant()
+
+    dock.show.assert_called_once_with()
+    dock.raise_.assert_called_once_with()
+    plugin.toggle_chat_dock.assert_not_called()
+
+
+def test_ai_assistant_button_loads_available_open_geoagent(monkeypatch):
+    plugin = SimpleNamespace(toggle_chat_dock=MagicMock(), _chat_dock=None)
+
+    def _load_plugin(package_name):
+        assert package_name == "open_geoagent"
+
+    def _start_plugin(package_name):
+        assert package_name == "open_geoagent"
+        qgis_utils.plugins = {"open_geoagent": plugin}
+
+    monkeypatch.setattr(qgis_utils, "plugins", {}, raising=False)
+    monkeypatch.setattr(
+        qgis_utils, "available_plugins", ["open_geoagent"], raising=False
+    )
+    monkeypatch.setattr(qgis_utils, "active_plugins", [], raising=False)
+    monkeypatch.setattr(qgis_utils, "loadPlugin", _load_plugin, raising=False)
+    monkeypatch.setattr(qgis_utils, "startPlugin", _start_plugin, raising=False)
+
+    GeeDataCatalogs(MagicMock()).open_ai_assistant()
+
+    plugin.toggle_chat_dock.assert_called_once_with()


### PR DESCRIPTION
## Summary
- Remove the embedded AI Assistant chat tab from the catalog dock and route the AI Assistant button to the standalone OpenGeoAgent plugin instead.
- Auto-load and start OpenGeoAgent when available; show an install prompt with a Plugin Manager shortcut when it is missing.
- Update the README feature blurb to describe the new launcher behavior.

## Test plan
- [ ] pytest tests/test_open_geoagent_launcher.py
- [ ] In QGIS without OpenGeoAgent installed, click the AI Assistant button and confirm the install prompt appears with a working Plugin Manager shortcut.
- [ ] In QGIS with OpenGeoAgent installed but inactive, click the button and confirm the plugin is loaded/started and its chat dock opens.
- [ ] With OpenGeoAgent already loaded and its chat dock visible, click the button and confirm the dock is raised rather than toggled off.