### PR TITLE
fix(ee): resolve real Python executable for EE auth

### DIFF
--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -1305,7 +1305,7 @@ def authenticate_ee(
                 "Install plugin dependencies first or run Earth Engine "
                 "authentication from the QGIS Python console.",
             )
-        env = os.environ.copy()
+        env = _get_clean_env_for_venv()
     else:
         return (
             False,

--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -1294,7 +1294,17 @@ def authenticate_ee(
         python_path = get_venv_python_path()
         env = _get_clean_env_for_venv()
     elif importlib.util.find_spec("ee") is not None:
-        python_path = sys.executable
+        try:
+            python_path = _find_python_executable()
+        except RuntimeError as exc:
+            _log(str(exc), Qgis.MessageLevel.Warning)
+            return (
+                False,
+                "earthengine-api is available in QGIS, but the plugin could not "
+                "find a real Python executable to run authentication. "
+                "Install plugin dependencies first or run Earth Engine "
+                "authentication from the QGIS Python console.",
+            )
         env = os.environ.copy()
     else:
         return (

--- a/gee_data_catalogs/metadata.txt
+++ b/gee_data_catalogs/metadata.txt
@@ -3,7 +3,7 @@ name=Earth Engine Data Catalogs
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Browse, search, and load Google Earth Engine data catalogs directly in QGIS.
-version=0.12.0
+version=0.12.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -37,6 +37,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.12.1
+        - Fix Earth Engine authentication launching QGIS instead of Python
     0.12.0
         - Route the AI Assistant button to the OpenGeoAgent chat panel
     0.11.1

--- a/tests/test_venv_manager_auth.py
+++ b/tests/test_venv_manager_auth.py
@@ -12,6 +12,10 @@ def test_authenticate_ee_falls_back_to_resolved_python(monkeypatch):
         calls["env"] = env
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
+    monkeypatch.setenv("PYTHONHOME", "/qgis/python")
+    monkeypatch.setenv("PYTHONPATH", "/qgis/python/site-packages")
+    monkeypatch.setenv("QGIS_PREFIX_PATH", "/qgis")
+
     monkeypatch.setattr(venv_manager, "venv_exists", lambda: False)
     monkeypatch.setattr(
         venv_manager.importlib.util,
@@ -30,7 +34,10 @@ def test_authenticate_ee_falls_back_to_resolved_python(monkeypatch):
     assert success is True
     assert "completed successfully" in message
     assert calls["cmd"][0] == resolved_python
-    assert "PYTHONPATH" in calls["env"] or isinstance(calls["env"], dict)
+    assert "PYTHONHOME" not in calls["env"]
+    assert "PYTHONPATH" not in calls["env"]
+    assert "QGIS_PREFIX_PATH" not in calls["env"]
+    assert calls["env"].get("PYTHONIOENCODING") == "utf-8"
 
 
 def test_authenticate_ee_reports_missing_python_executable(monkeypatch):

--- a/tests/test_venv_manager_auth.py
+++ b/tests/test_venv_manager_auth.py
@@ -1,11 +1,11 @@
-import sys
 import types
 
 from gee_data_catalogs.core import venv_manager
 
 
-def test_authenticate_ee_falls_back_to_current_python(monkeypatch):
+def test_authenticate_ee_falls_back_to_resolved_python(monkeypatch):
     calls = {}
+    resolved_python = r"C:\Program Files\QGIS 4.0.1\apps\Python312\python.exe"
 
     def fake_run(cmd, capture_output, text, timeout, env, **kwargs):
         calls["cmd"] = cmd
@@ -18,14 +18,38 @@ def test_authenticate_ee_falls_back_to_current_python(monkeypatch):
         "find_spec",
         lambda name: object() if name == "ee" else None,
     )
+    monkeypatch.setattr(
+        venv_manager,
+        "_find_python_executable",
+        lambda: resolved_python,
+    )
     monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
 
     success, message = venv_manager.authenticate_ee()
 
     assert success is True
     assert "completed successfully" in message
-    assert calls["cmd"][0] == sys.executable
+    assert calls["cmd"][0] == resolved_python
     assert "PYTHONPATH" in calls["env"] or isinstance(calls["env"], dict)
+
+
+def test_authenticate_ee_reports_missing_python_executable(monkeypatch):
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda: False)
+    monkeypatch.setattr(
+        venv_manager.importlib.util,
+        "find_spec",
+        lambda name: object() if name == "ee" else None,
+    )
+    monkeypatch.setattr(
+        venv_manager,
+        "_find_python_executable",
+        lambda: (_ for _ in ()).throw(RuntimeError("not found")),
+    )
+
+    success, message = venv_manager.authenticate_ee()
+
+    assert success is False
+    assert "could not find a real Python executable" in message
 
 
 def test_authenticate_ee_reports_missing_envs(monkeypatch):


### PR DESCRIPTION
## Summary
- Fix Earth Engine authentication when `earthengine-api` is importable directly inside QGIS: previously the code launched the auth subprocess with `sys.executable`, which on Windows is the QGIS host binary and cannot run `ee.Authenticate()`.
- Resolve a real Python interpreter via `_find_python_executable()` and surface a clear error message if none can be located, instead of silently launching QGIS again.
- Bump plugin version to 0.12.1 with a changelog entry; update the auth fallback test and add a new test for the missing-executable error path.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/test_venv_manager_auth.py`
- [ ] Manual: trigger Earth Engine authentication from the plugin on a QGIS install where `earthengine-api` is importable in QGIS itself, confirm a real Python is launched (or a clear error is shown if not found).