### PR TITLE
Fix macOS QGIS dependency installer

### DIFF
--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -452,7 +452,9 @@ def create_venv(
 
     if use_uv:
         uv_path = get_uv_path()
-        uv_python = system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        uv_python = (
+            system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        )
         cmd = [uv_path, "venv"]
         if system_python is None:
             cmd.append("--managed-python")

--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -198,9 +198,25 @@ def _is_python_executable_name(path: str) -> bool:
     )
 
 
+def _is_macos_qgis_app_bundle_python(path: str) -> bool:
+    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    if not (platform.system() == "Darwin" or sys.platform == "darwin"):
+        return False
+    parts = os.path.abspath(path).split(os.sep)
+    for idx, part in enumerate(parts):
+        lower = part.lower()
+        if not (lower.startswith("qgis") and lower.endswith(".app")):
+            continue
+        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+    return False
+
+
 def _python_candidate_matches_runtime(path: str) -> bool:
     """Return True when a candidate is executable and matches QGIS Python."""
     if not path or not os.path.isfile(path) or not _is_python_executable_name(path):
+        return False
+
+    if _is_macos_qgis_app_bundle_python(path):
         return False
     try:
         result = subprocess.run(  # nosec B603
@@ -421,11 +437,14 @@ def create_venv(
     if progress_callback:
         progress_callback(10, "Creating virtual environment...")
 
+    system_python = None
+    python_lookup_error = ""
     try:
         system_python = _get_system_python()
     except RuntimeError as exc:
-        return False, str(exc)
-    _log(f"Using Python: {system_python}")
+        python_lookup_error = str(exc)
+    if system_python:
+        _log(f"Using Python: {system_python}")
 
     from .uv_manager import get_uv_path, uv_exists
 
@@ -433,9 +452,15 @@ def create_venv(
 
     if use_uv:
         uv_path = get_uv_path()
-        cmd = [uv_path, "venv", "--python", system_python, venv_dir]
+        uv_python = system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        cmd = [uv_path, "venv"]
+        if system_python is None:
+            cmd.append("--managed-python")
+        cmd += ["--python", uv_python, venv_dir]
         _log("Creating venv with uv")
     else:
+        if system_python is None:
+            return False, python_lookup_error
         cmd = [system_python, "-m", "venv", venv_dir]
         _log("Creating venv with stdlib venv")
 

--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -199,7 +199,7 @@ def _is_python_executable_name(path: str) -> bool:
 
 
 def _is_macos_qgis_app_bundle_python(path: str) -> bool:
-    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    """Return True for unsafe Python launchers in QGIS.app/Contents/MacOS."""
     if not (platform.system() == "Darwin" or sys.platform == "darwin"):
         return False
     parts = os.path.abspath(path).split(os.sep)
@@ -207,7 +207,12 @@ def _is_macos_qgis_app_bundle_python(path: str) -> bool:
         lower = part.lower()
         if not (lower.startswith("qgis") and lower.endswith(".app")):
             continue
-        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+        if idx + 2 >= len(parts):
+            return False
+        if parts[idx + 1].lower() != "contents" or parts[idx + 2].lower() != "macos":
+            return False
+        name = os.path.basename(path).lower()
+        return name.startswith("qgis") or _is_python_executable_name(path)
     return False
 
 
@@ -443,6 +448,12 @@ def create_venv(
         system_python = _get_system_python()
     except RuntimeError as exc:
         python_lookup_error = str(exc)
+    if python_lookup_error and system_python is None:
+        _log(
+            "Python lookup failed; falling back to uv-managed Python if "
+            f"available: {python_lookup_error}",
+            Qgis.MessageLevel.Warning,
+        )
     if system_python:
         _log(f"Using Python: {system_python}")
 
@@ -534,10 +545,12 @@ def create_venv(
         _cleanup_partial_venv(venv_dir)
         return False, "Virtual environment creation timed out"
     except FileNotFoundError:
+        missing_executable = cmd[0] if cmd else system_python
         _log(
-            f"Python executable not found: {system_python}", Qgis.MessageLevel.Critical
+            f"Venv creation executable not found: {missing_executable}",
+            Qgis.MessageLevel.Critical,
         )
-        return False, f"Python not found: {system_python}"
+        return False, f"Executable not found: {missing_executable}"
     except Exception as e:
         _log(f"Exception during venv creation: {str(e)}", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)

--- a/gee_data_catalogs/metadata.txt
+++ b/gee_data_catalogs/metadata.txt
@@ -3,7 +3,7 @@ name=Earth Engine Data Catalogs
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Browse, search, and load Google Earth Engine data catalogs directly in QGIS.
-version=0.12.1
+version=0.12.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 

--- a/gee_data_catalogs/metadata.txt
+++ b/gee_data_catalogs/metadata.txt
@@ -36,7 +36,7 @@ icon=icons/icon.svg
 experimental=False
 deprecated=False
 
-changelog=
+changelog=Fix macOS QGIS installer dependency installation and bump patch version.
     0.12.1
         - Fix Earth Engine authentication launching QGIS instead of Python
     0.12.0

--- a/gee_data_catalogs/metadata.txt
+++ b/gee_data_catalogs/metadata.txt
@@ -36,7 +36,9 @@ icon=icons/icon.svg
 experimental=False
 deprecated=False
 
-changelog=Fix macOS QGIS installer dependency installation and bump patch version.
+changelog=
+    0.12.2
+        - Fix macOS QGIS installer dependency installation
     0.12.1
         - Fix Earth Engine authentication launching QGIS instead of Python
     0.12.0

--- a/tests/test_venv_manager_auth.py
+++ b/tests/test_venv_manager_auth.py
@@ -1,6 +1,43 @@
 import types
 
 from gee_data_catalogs.core import venv_manager
+from gee_data_catalogs.core import uv_manager
+
+
+def test_create_venv_uses_uv_managed_python_when_system_python_missing(
+    monkeypatch, tmp_path
+):
+    calls = {}
+    venv_dir = str(tmp_path / "venv")
+
+    def fake_run(cmd, capture_output, text, timeout, env, **kwargs):
+        calls["cmd"] = cmd
+        calls["env"] = env
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        venv_manager,
+        "_get_system_python",
+        lambda: (_ for _ in ()).throw(RuntimeError("no local python")),
+    )
+    monkeypatch.setattr(uv_manager, "uv_exists", lambda: True)
+    monkeypatch.setattr(uv_manager, "get_uv_path", lambda: "/tmp/uv")
+    monkeypatch.setattr(venv_manager.subprocess, "run", fake_run)
+
+    success, message = venv_manager.create_venv(venv_dir=venv_dir)
+
+    assert success is True
+    assert message == "Virtual environment created"
+    assert calls["cmd"] == [
+        "/tmp/uv",
+        "venv",
+        "--managed-python",
+        "--python",
+        f"{venv_manager.sys.version_info.major}.{venv_manager.sys.version_info.minor}",
+        venv_dir,
+    ]
+    assert "PYTHONHOME" not in calls["env"]
+    assert "PYTHONPATH" not in calls["env"]
 
 
 def test_authenticate_ee_falls_back_to_resolved_python(monkeypatch):


### PR DESCRIPTION
## Summary
- Reject macOS QGIS app-bundle Python wrappers for dependency virtual environment creation where this plugin manages dependency venvs.
- Use uv-managed Python when no safe local Python interpreter is available.
- Bump the QGIS plugin patch version in `metadata.txt`.

## Root Cause
Official macOS QGIS installer builds can expose Python wrappers inside `QGIS*.app/Contents/MacOS` that either fail to start outside QGIS or create virtual environments pointing at the QGIS CI build prefix. Those venvs fail during dependency installation with missing stdlib modules such as `encodings`.

## Validation
- `python -m py_compile gee_data_catalogs/core/venv_manager.py`
- Focused local QGIS plugin tests were run from the source checkout before publishing these PRs.
