### PR TITLE
feat(catalog): add favorites, recipes, ranked search, and processing provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A comprehensive QGIS plugin for browsing, searching, and loading Google Earth En
   - [Official Earth Engine Data Catalog](https://github.com/opengeos/Earth-Engine-Catalog) - 780+ datasets
   - [Awesome GEE Community Catalog](https://github.com/samapriya/awesome-gee-community-datasets) - 4,360+ community datasets
 - **Search & Filter**: Search datasets by keywords, tags, providers, data types, and sources
+- **Ranked Search & Saved Workflows**: Relevance-ranked search, favorites, recent datasets, and reusable analysis recipes
+- **Persistent Catalog Cache**: Disk-backed catalog cache for faster startup and offline fallback
 - **Advanced Filtering for ImageCollections**:
   - Date range filtering
   - Bounding box (current map extent)
@@ -25,7 +27,10 @@ A comprehensive QGIS plugin for browsing, searching, and loading Google Earth En
 - **Conversion**: Convert Earth Engine JavaScript API to Python API
 - **Inspector**: Inspect Earth Engine layer values at specific locations
 - **Export**: Export Earth Engine layers to various file formats
+- **Export Queue & History**: Queue multiple exports and keep recent export job status
 - **AI Assistant**: Open the OpenGeoAgent chat panel for Earth Engine dataset and QGIS map assistance
+- **Project Snapshot**: Copy/share current EE layers, map extent, selected dataset, and QGIS layer context
+- **QGIS Processing Provider**: Run catalog search, snippet generation, and EE asset loading from QGIS Processing/Model Builder
 - **Multiple Data Types**: Load EE Image, ImageCollection, and FeatureCollection layers
 - **Integration**: Works seamlessly with [qgis-geemap-plugin](https://github.com/opengeos/qgis-geemap-plugin)
 - **Update Checker**: Built-in plugin update checker from GitHub

--- a/gee_data_catalogs/core/catalog_data.py
+++ b/gee_data_catalogs/core/catalog_data.py
@@ -1062,13 +1062,15 @@ def search_datasets(
         results.append(result)
 
     if query_lower:
+        # Sort by score desc, official-source desc, then name asc.
+        # We invert the numeric/boolean keys so reverse=True is unnecessary,
+        # otherwise the name tie-breaker would also be reversed.
         results.sort(
             key=lambda item: (
-                item.get("_search_score", 0),
-                item.get("source") == "official",
+                -item.get("_search_score", 0),
+                0 if item.get("source") == "official" else 1,
                 str(item.get("name", "")),
-            ),
-            reverse=True,
+            )
         )
 
     return results

--- a/gee_data_catalogs/core/catalog_data.py
+++ b/gee_data_catalogs/core/catalog_data.py
@@ -11,6 +11,7 @@ import csv
 import io
 import json
 import os
+import time
 from typing import Any, Dict, List, Optional
 from urllib.request import urlopen
 from urllib.error import URLError, HTTPError
@@ -31,6 +32,109 @@ _catalog_cache = {
     "community": None,
     "last_update": None,
 }
+
+_DISK_CACHE_VERSION = 1
+
+
+def _cache_dir() -> str:
+    """Return the plugin cache directory."""
+    base = (
+        os.environ.get("XDG_CACHE_HOME")
+        or os.environ.get("LOCALAPPDATA")
+        or os.path.join(os.path.expanduser("~"), ".cache")
+    )
+    return os.path.join(base, "qgis-gee-data-catalogs")
+
+
+def _cache_path(source: str) -> str:
+    return os.path.join(_cache_dir(), f"{source}_catalog.json")
+
+
+def _cache_settings() -> tuple[bool, int]:
+    """Return whether disk cache is enabled and its max age in hours."""
+    try:
+        settings = QgsSettings()
+        enabled = settings.value("GeeDataCatalogs/cache_enabled", True, type=bool)
+        duration = settings.value("GeeDataCatalogs/cache_duration", 24, type=int)
+        return bool(enabled), max(1, int(duration))
+    except Exception:
+        return True, 24
+
+
+def _read_disk_cache(source: str) -> Optional[List[Dict]]:
+    enabled, duration_hours = _cache_settings()
+    if not enabled:
+        return None
+
+    path = _cache_path(source)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        if payload.get("version") != _DISK_CACHE_VERSION:
+            return None
+        created_at = float(payload.get("created_at", 0))
+        if time.time() - created_at > duration_hours * 3600:
+            return None
+        datasets = payload.get("datasets")
+        if isinstance(datasets, list):
+            QgsMessageLog.logMessage(
+                f"Loaded {len(datasets)} {source} datasets from disk cache",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Info,
+            )
+            return datasets
+    except FileNotFoundError:
+        return None
+    except Exception as exc:
+        QgsMessageLog.logMessage(
+            f"Failed to read {source} catalog cache: {exc}",
+            "GEE Data Catalogs",
+            Qgis.MessageLevel.Warning,
+        )
+    return None
+
+
+def _write_disk_cache(source: str, datasets: List[Dict]) -> None:
+    enabled, _duration_hours = _cache_settings()
+    if not enabled:
+        return
+    try:
+        os.makedirs(_cache_dir(), exist_ok=True)
+        with open(_cache_path(source), "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "version": _DISK_CACHE_VERSION,
+                    "created_at": time.time(),
+                    "datasets": datasets,
+                },
+                f,
+            )
+    except Exception as exc:
+        QgsMessageLog.logMessage(
+            f"Failed to write {source} catalog cache: {exc}",
+            "GEE Data Catalogs",
+            Qgis.MessageLevel.Warning,
+        )
+
+
+def _read_any_disk_cache(source: str) -> Optional[List[Dict]]:
+    """Return stale cache as a network-failure fallback."""
+    path = _cache_path(source)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        datasets = payload.get("datasets")
+        if isinstance(datasets, list):
+            QgsMessageLog.logMessage(
+                f"Using stale {source} catalog cache with {len(datasets)} datasets",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
+            )
+            return datasets
+    except Exception:
+        return None
+    return None
+
 
 # Default categories for organizing datasets (aligned with official GEE categories)
 # https://developers.google.com/earth-engine/datasets/categories
@@ -654,6 +758,12 @@ def fetch_official_catalog(use_cache: bool = True) -> List[Dict]:
     if use_cache and _catalog_cache["official"] is not None:
         return _catalog_cache["official"]
 
+    if use_cache:
+        cached = _read_disk_cache("official")
+        if cached is not None:
+            _catalog_cache["official"] = cached
+            return cached
+
     datasets = []
 
     # Try JSON first, then TSV
@@ -678,6 +788,7 @@ def fetch_official_catalog(use_cache: bool = True) -> List[Dict]:
                         Qgis.MessageLevel.Info,
                     )
                     _catalog_cache["official"] = datasets
+                    _write_disk_cache("official", datasets)
                     return datasets
         except (HTTPError, URLError) as e:
             QgsMessageLog.logMessage(
@@ -691,6 +802,11 @@ def fetch_official_catalog(use_cache: bool = True) -> List[Dict]:
                 "GEE Data Catalogs",
                 Qgis.MessageLevel.Warning,
             )
+
+    cached = _read_any_disk_cache("official")
+    if cached is not None:
+        _catalog_cache["official"] = cached
+        return cached
 
     return datasets
 
@@ -708,6 +824,12 @@ def fetch_community_catalog(use_cache: bool = True) -> List[Dict]:
 
     if use_cache and _catalog_cache["community"] is not None:
         return _catalog_cache["community"]
+
+    if use_cache:
+        cached = _read_disk_cache("community")
+        if cached is not None:
+            _catalog_cache["community"] = cached
+            return cached
 
     datasets = []
 
@@ -733,6 +855,7 @@ def fetch_community_catalog(use_cache: bool = True) -> List[Dict]:
                         Qgis.MessageLevel.Info,
                     )
                     _catalog_cache["community"] = datasets
+                    _write_disk_cache("community", datasets)
                     return datasets
         except (HTTPError, URLError) as e:
             QgsMessageLog.logMessage(
@@ -746,6 +869,11 @@ def fetch_community_catalog(use_cache: bool = True) -> List[Dict]:
                 "GEE Data Catalogs",
                 Qgis.MessageLevel.Warning,
             )
+
+    cached = _read_any_disk_cache("community")
+    if cached is not None:
+        _catalog_cache["community"] = cached
+        return cached
 
     return datasets
 
@@ -865,6 +993,7 @@ def search_datasets(
     datasets = get_all_datasets(include_community=include_community)
     results = []
     query_lower = query.lower().strip()
+    query_terms = [term for term in query_lower.split() if term]
 
     for dataset in datasets:
         # Check category filter
@@ -886,31 +1015,61 @@ def search_datasets(
         if source and dataset.get("source") != source:
             continue
 
+        score = 0
+
         # Check query match
         if query_lower:
             matches = False
-            search_fields = [
-                str(dataset.get("name", "")).lower(),
-                str(dataset.get("title", "")).lower(),
-                str(dataset.get("description", "")).lower(),
-                str(dataset.get("id", "")).lower(),
+            weighted_fields = [
+                (str(dataset.get("name", "")).lower(), 80),
+                (str(dataset.get("title", "")).lower(), 80),
+                (str(dataset.get("id", "")).lower(), 60),
+                (str(dataset.get("provider", "")).lower(), 35),
+                (str(dataset.get("category", "")).lower(), 30),
+                (str(dataset.get("description", "")).lower(), 12),
             ]
             # Add keywords
             keywords = dataset.get("keywords", [])
             if isinstance(keywords, list):
-                search_fields.extend([k.lower() for k in keywords])
+                weighted_fields.extend((k.lower(), 40) for k in keywords)
             else:
-                search_fields.append(str(keywords).lower())
+                weighted_fields.append((str(keywords).lower(), 40))
 
-            for field in search_fields:
+            for field, weight in weighted_fields:
                 if query_lower in field:
                     matches = True
-                    break
+                    score += weight * 2
+                for term in query_terms:
+                    if term in field:
+                        matches = True
+                        score += weight
+
+            # Prefer exact ID/name matches and official catalog entries when
+            # relevance is otherwise similar.
+            if query_lower == str(dataset.get("id", "")).lower():
+                score += 500
+            if query_lower == str(dataset.get("name", "")).lower():
+                score += 400
+            if dataset.get("source") == "official":
+                score += 5
 
             if not matches:
                 continue
 
-        results.append(dataset)
+        result = dict(dataset)
+        if query_lower:
+            result["_search_score"] = score
+        results.append(result)
+
+    if query_lower:
+        results.sort(
+            key=lambda item: (
+                item.get("_search_score", 0),
+                item.get("source") == "official",
+                str(item.get("name", "")),
+            ),
+            reverse=True,
+        )
 
     return results
 

--- a/gee_data_catalogs/core/ee_utils.py
+++ b/gee_data_catalogs/core/ee_utils.py
@@ -59,6 +59,64 @@ _tile_url_cache: Dict[tuple, str] = {}
 _TILE_CACHE_CAP = 64
 
 
+def _colormap_colors(name: str, n_colors: int = 256) -> List[str]:
+    """Return sampled hex colors for a Matplotlib colormap name.
+
+    Earth Engine palettes accept CSS colors, not colormap names like
+    ``terrain``. The Load tab has long accepted those names by expanding them
+    before calling ``add_ee_layer``; this helper makes the same normalization
+    available to Code tab snippets and any direct API caller.
+    """
+    if not name or "," in name or name.startswith("#") or name.startswith("rgb"):
+        return []
+
+    try:
+        import matplotlib.colors as mcolors
+        import matplotlib.pyplot as plt
+
+        cmap = plt.get_cmap(name)
+        return [mcolors.to_hex(cmap(i / (n_colors - 1))) for i in range(n_colors)]
+    except Exception:
+        return []
+
+
+def normalize_vis_params(vis_params: Optional[Dict]) -> Dict:
+    """Normalize visualization parameters before sending them to Earth Engine."""
+    normalized = dict(vis_params or {})
+    palette = normalized.get("palette")
+    if not palette:
+        return normalized
+
+    if isinstance(palette, str):
+        if "," in palette:
+            normalized["palette"] = [
+                color.strip().strip("\"'")
+                for color in palette.split(",")
+                if color.strip().strip("\"'")
+            ]
+            return normalized
+
+        colors = _colormap_colors(palette.strip())
+        if colors:
+            normalized["palette"] = colors
+        return normalized
+
+    if isinstance(palette, (list, tuple)):
+        palette_list = [
+            str(color).strip().strip("\"'")
+            for color in palette
+            if str(color).strip().strip("\"'")
+        ]
+        if len(palette_list) == 1:
+            colors = _colormap_colors(palette_list[0])
+            if colors:
+                normalized["palette"] = colors
+                return normalized
+        normalized["palette"] = palette_list
+
+    return normalized
+
+
 def _hashable_vis_params(vis_params: Dict) -> tuple:
     """Return a hashable representation of vis_params for use as a cache key.
 
@@ -317,7 +375,7 @@ def get_ee_tile_url(
             "The 'ee' module is not installed. Please install earthengine-api."
         )
 
-    vis_params = vis_params or {}
+    vis_params = normalize_vis_params(vis_params)
 
     # Handle ImageCollection by taking the first image or mosaic
     if isinstance(ee_object, ee.ImageCollection):
@@ -378,6 +436,21 @@ def _is_valid_qgis_layer(layer: Any) -> bool:
         return False
 
 
+def _apply_layer_name(layer: Any, name: str) -> None:
+    """Ensure a QGIS layer returned by another helper uses our requested name."""
+    if not name or not hasattr(layer, "setName"):
+        return
+    try:
+        if not hasattr(layer, "name") or layer.name() != name:
+            layer.setName(name)
+    except Exception as exc:
+        QgsMessageLog.logMessage(
+            f"Could not rename Earth Engine layer to '{name}': {exc}",
+            "GEE Data Catalogs",
+            Qgis.MessageLevel.Warning,
+        )
+
+
 def _create_xyz_ee_layer(
     ee_object: Any,
     vis_params: Dict,
@@ -435,7 +508,7 @@ def add_ee_layer(
             "The 'ee' module is not installed. Please install earthengine-api."
         )
 
-    vis_params = vis_params or {}
+    vis_params = normalize_vis_params(vis_params)
 
     # Remove existing layer with the same name if it exists
     project = QgsProject.instance()
@@ -481,6 +554,8 @@ def add_ee_layer(
         layer = None
 
     if layer is not None:
+        _apply_layer_name(layer, name)
+
         # Restore the map extent after qgis_geemap adds the layer
         if current_extent and iface and iface.mapCanvas():
             iface.mapCanvas().setExtent(current_extent)

--- a/gee_data_catalogs/core/user_state.py
+++ b/gee_data_catalogs/core/user_state.py
@@ -1,0 +1,307 @@
+"""Persistent user state for the GEE Data Catalogs plugin."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from qgis.PyQt.QtCore import QSettings
+
+SETTINGS_PREFIX = "GeeDataCatalogs/"
+MAX_RECENTS = 30
+MAX_EXPORT_HISTORY = 50
+
+
+DEFAULT_RECIPES: List[Dict[str, Any]] = [
+    {
+        "id": "sentinel2_median",
+        "name": "Sentinel-2 Cloud-Masked Median",
+        "category": "Satellite Imagery",
+        "asset_id": "COPERNICUS/S2_SR_HARMONIZED",
+        "type": "ImageCollection",
+        "target": "load",
+        "bands": "B4,B3,B2",
+        "min": 0,
+        "max": 3000,
+        "cloud_cover": 20,
+        "description": "RGB median composite from Sentinel-2 surface reflectance.",
+    },
+    {
+        "id": "landsat9_rgb",
+        "name": "Landsat 9 Surface Reflectance RGB",
+        "category": "Satellite Imagery",
+        "asset_id": "LANDSAT/LC09/C02/T1_L2",
+        "type": "ImageCollection",
+        "target": "load",
+        "bands": "SR_B4,SR_B3,SR_B2",
+        "min": 0,
+        "max": 30000,
+        "cloud_cover": 20,
+        "description": "Landsat 9 Collection 2 Level 2 RGB composite.",
+    },
+    {
+        "id": "hls_s30_rgb",
+        "name": "HLS Sentinel-2 RGB Composite",
+        "category": "Satellite Imagery",
+        "asset_id": "NASA/HLS/HLSS30/v002",
+        "type": "ImageCollection",
+        "target": "load",
+        "bands": "B4,B3,B2",
+        "min": 0,
+        "max": 0.3,
+        "cloud_cover": 20,
+        "description": "Harmonized Landsat Sentinel-2 Sentinel-2 MSI true-color surface reflectance composite.",
+    },
+    {
+        "id": "hls_l30_rgb",
+        "name": "HLS Landsat RGB Composite",
+        "category": "Satellite Imagery",
+        "asset_id": "NASA/HLS/HLSL30/v002",
+        "type": "ImageCollection",
+        "target": "load",
+        "bands": "B4,B3,B2",
+        "min": 0,
+        "max": 0.3,
+        "cloud_cover": 20,
+        "description": "Harmonized Landsat Sentinel-2 Landsat OLI true-color surface reflectance composite.",
+    },
+    {
+        "id": "hls_s30_false_color",
+        "name": "HLS Sentinel-2 False Color Vegetation",
+        "category": "Vegetation Indices",
+        "asset_id": "NASA/HLS/HLSS30/v002",
+        "type": "ImageCollection",
+        "target": "load",
+        "bands": "B8A,B4,B3",
+        "min": 0,
+        "max": 0.4,
+        "cloud_cover": 20,
+        "description": "HLS Sentinel-2 near-infrared, red, and green composite for vegetation contrast.",
+    },
+    {
+        "id": "hls_l30_false_color",
+        "name": "HLS Landsat False Color Vegetation",
+        "category": "Vegetation Indices",
+        "asset_id": "NASA/HLS/HLSL30/v002",
+        "type": "ImageCollection",
+        "target": "load",
+        "bands": "B5,B4,B3",
+        "min": 0,
+        "max": 0.4,
+        "cloud_cover": 20,
+        "description": "HLS Landsat near-infrared, red, and green composite for vegetation contrast.",
+    },
+    {
+        "id": "hls_s30_swir_burn",
+        "name": "HLS Sentinel-2 SWIR Burn/Water Composite",
+        "category": "Fire",
+        "asset_id": "NASA/HLS/HLSS30/v002",
+        "type": "ImageCollection",
+        "target": "load",
+        "bands": "B12,B8A,B4",
+        "min": 0,
+        "max": 0.5,
+        "cloud_cover": 20,
+        "description": "HLS Sentinel-2 SWIR, NIR, and red composite useful for burn scars, moisture, and water mapping.",
+    },
+    {
+        "id": "hls_l30_swir_burn",
+        "name": "HLS Landsat SWIR Burn/Water Composite",
+        "category": "Fire",
+        "asset_id": "NASA/HLS/HLSL30/v002",
+        "type": "ImageCollection",
+        "target": "load",
+        "bands": "B7,B5,B4",
+        "min": 0,
+        "max": 0.5,
+        "cloud_cover": 20,
+        "description": "HLS Landsat SWIR2, NIR, and red composite useful for burn scars, moisture, and water mapping.",
+    },
+    {
+        "id": "hls_s30_reflectance_timeseries",
+        "name": "HLS Sentinel-2 Reflectance Time Series",
+        "category": "Satellite Imagery",
+        "asset_id": "NASA/HLS/HLSS30/v002",
+        "type": "ImageCollection",
+        "target": "timeseries",
+        "bands": "B2,B3,B4,B8A,B11,B12",
+        "min": 0,
+        "max": 0.5,
+        "cloud_cover": 20,
+        "description": "Pixel time-series setup for HLS Sentinel-2 visible, NIR, and SWIR reflectance bands.",
+    },
+    {
+        "id": "hls_l30_reflectance_timeseries",
+        "name": "HLS Landsat Reflectance Time Series",
+        "category": "Satellite Imagery",
+        "asset_id": "NASA/HLS/HLSL30/v002",
+        "type": "ImageCollection",
+        "target": "timeseries",
+        "bands": "B2,B3,B4,B5,B6,B7",
+        "min": 0,
+        "max": 0.5,
+        "cloud_cover": 20,
+        "description": "Pixel time-series setup for HLS Landsat visible, NIR, and SWIR reflectance bands.",
+    },
+    {
+        "id": "dynamic_world",
+        "name": "Dynamic World Land Cover",
+        "category": "Land Use & Land Cover",
+        "asset_id": "GOOGLE/DYNAMICWORLD/V1",
+        "type": "ImageCollection",
+        "target": "load",
+        "bands": "label",
+        "min": 0,
+        "max": 8,
+        "palette": "419bdf,397d49,88b053,7a87c6,e49635,dfc35a,c4281b,a59b8f,b39fe1",
+        "description": "Near-real-time 10 m land cover labels.",
+    },
+    {
+        "id": "srtm_hillshade",
+        "name": "SRTM Elevation",
+        "category": "Elevation & Topography",
+        "asset_id": "USGS/SRTMGL1_003",
+        "type": "Image",
+        "target": "load",
+        "bands": "elevation",
+        "min": 0,
+        "max": 4000,
+        "palette": "006400,7fff00,ffff00,ff8c00,8b4513,ffffff",
+        "description": "Global 30 m elevation for terrain context.",
+    },
+    {
+        "id": "modis_ndvi_timeseries",
+        "name": "MODIS NDVI Time Series",
+        "category": "Vegetation Indices",
+        "asset_id": "MODIS/061/MOD13Q1",
+        "type": "ImageCollection",
+        "target": "timeseries",
+        "bands": "NDVI",
+        "min": 0,
+        "max": 9000,
+        "description": "16-day MODIS vegetation-index time series.",
+    },
+]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _settings() -> QSettings:
+    return QSettings()
+
+
+def _read_json(key: str, default: Any) -> Any:
+    raw = _settings().value(f"{SETTINGS_PREFIX}{key}", "", type=str)
+    if not raw:
+        return default
+    try:
+        return json.loads(raw)
+    except Exception:
+        return default
+
+
+def _write_json(key: str, value: Any) -> None:
+    _settings().setValue(f"{SETTINGS_PREFIX}{key}", json.dumps(value))
+
+
+def dataset_summary(dataset: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a compact, settings-safe dataset record."""
+    keys = (
+        "id",
+        "name",
+        "title",
+        "type",
+        "source",
+        "provider",
+        "category",
+        "description",
+        "thumbnail",
+        "url",
+        "docs",
+        "script",
+        "sample_code",
+        "start_date",
+        "end_date",
+        "keywords",
+        "vis_params",
+        "bigquery_table",
+    )
+    return {key: dataset.get(key) for key in keys if dataset.get(key) not in (None, "")}
+
+
+def get_favorites() -> List[Dict[str, Any]]:
+    return _read_json("favorites", [])
+
+
+def is_favorite(asset_id: str) -> bool:
+    return any(item.get("id") == asset_id for item in get_favorites())
+
+
+def add_favorite(dataset: Dict[str, Any]) -> List[Dict[str, Any]]:
+    record = dataset_summary(dataset)
+    if not record.get("id"):
+        return get_favorites()
+    record["favorited_at"] = _now_iso()
+    favorites = [item for item in get_favorites() if item.get("id") != record["id"]]
+    favorites.insert(0, record)
+    _write_json("favorites", favorites)
+    return favorites
+
+
+def remove_favorite(asset_id: str) -> List[Dict[str, Any]]:
+    favorites = [item for item in get_favorites() if item.get("id") != asset_id]
+    _write_json("favorites", favorites)
+    return favorites
+
+
+def get_recents() -> List[Dict[str, Any]]:
+    return _read_json("recent_datasets", [])
+
+
+def record_recent_dataset(
+    dataset: Dict[str, Any], action: str = "load"
+) -> List[Dict[str, Any]]:
+    record = dataset_summary(dataset)
+    if not record.get("id"):
+        return get_recents()
+    record["last_action"] = action
+    record["last_used_at"] = _now_iso()
+    recents = [item for item in get_recents() if item.get("id") != record["id"]]
+    recents.insert(0, record)
+    recents = recents[:MAX_RECENTS]
+    _write_json("recent_datasets", recents)
+    return recents
+
+
+def get_recipes() -> List[Dict[str, Any]]:
+    custom = _read_json("custom_recipes", [])
+    return DEFAULT_RECIPES + custom
+
+
+def get_export_history() -> List[Dict[str, Any]]:
+    return _read_json("export_history", [])
+
+
+def record_export_job(
+    job: Dict[str, Any], status: str, message: str = ""
+) -> List[Dict[str, Any]]:
+    record = dict(job)
+    record["status"] = status
+    record["message"] = message
+    record["updated_at"] = _now_iso()
+    history = get_export_history()
+    history.insert(0, record)
+    history = history[:MAX_EXPORT_HISTORY]
+    _write_json("export_history", history)
+    return history
+
+
+def find_dataset_record(asset_id: str) -> Optional[Dict[str, Any]]:
+    for collection in (get_favorites(), get_recents()):
+        for item in collection:
+            if item.get("id") == asset_id:
+                return item
+    return None

--- a/gee_data_catalogs/dialogs/catalog_dock.py
+++ b/gee_data_catalogs/dialogs/catalog_dock.py
@@ -7,7 +7,7 @@ and loading Google Earth Engine datasets.
 
 from datetime import datetime, timedelta
 
-from qgis.PyQt.QtCore import Qt, QCoreApplication, QThread, pyqtSignal, QTimer
+from qgis.PyQt.QtCore import Qt, QCoreApplication, QEvent, QThread, pyqtSignal, QTimer
 from qgis.PyQt.QtWidgets import (
     QDockWidget,
     QWidget,
@@ -40,6 +40,7 @@ from qgis.PyQt.QtWidgets import (
     QButtonGroup,
     QSlider,
     QFileDialog,
+    QHeaderView,
 )
 from qgis.PyQt.QtGui import QFont, QCursor
 from qgis.core import QgsProject, QgsRectangle, QgsMessageLog, Qgis
@@ -1389,8 +1390,16 @@ class TimeSeriesChartDialog(QWidget):
         self.band_list = QListWidget()
         self.band_list.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
         self.band_list.setMaximumHeight(100)
-        self.band_list.itemSelectionChanged.connect(self._update_chart)
+        self.band_list.itemSelectionChanged.connect(self._on_band_selection_changed)
         band_layout.addWidget(self.band_list)
+
+        band_button_layout = QVBoxLayout()
+        self.clear_bands_btn = QPushButton("Clear Bands")
+        self.clear_bands_btn.setToolTip("Clear all selected bands from the chart.")
+        self.clear_bands_btn.clicked.connect(self._clear_selected_bands)
+        band_button_layout.addWidget(self.clear_bands_btn)
+        band_button_layout.addStretch()
+        band_layout.addLayout(band_button_layout)
         layout.addLayout(band_layout)
 
         # Chart options
@@ -1516,13 +1525,7 @@ class TimeSeriesChartDialog(QWidget):
             f"Time Series at ({lon:.6f}, {lat:.6f})\n" f"Dataset: {asset_id}"
         )
 
-        # Populate band list
-        self.band_list.clear()
-        bands = data.get("bands", [])
-        for band in bands:
-            item = QListWidgetItem(band)
-            self.band_list.addItem(item)
-            item.setSelected(True)  # Select all bands by default
+        self._populate_band_list(data.get("bands", []), selected_bands=None)
 
         self._update_chart()
         self._update_stats()
@@ -1553,15 +1556,16 @@ class TimeSeriesChartDialog(QWidget):
                 f"Dataset: {asset_id}"
             )
 
-        # Populate band list from first location
-        self.band_list.clear()
+        # Preserve the user's current band selection when adding more locations.
+        # A fresh chart selects all bands; after that, new points should honor
+        # whatever bands are already selected in the panel, including none.
+        had_existing_band_list = self.band_list.count() > 0
+        previous_selection = set(self._get_selected_bands())
         if multi_data:
             first_data = list(multi_data.values())[0]
             bands = first_data.get("bands", [])
-            for band in bands:
-                item = QListWidgetItem(band)
-                self.band_list.addItem(item)
-                item.setSelected(True)
+            selected_bands = previous_selection if had_existing_band_list else None
+            self._populate_band_list(bands, selected_bands=selected_bands)
 
         self._update_chart()
         self._update_stats()
@@ -1570,6 +1574,63 @@ class TimeSeriesChartDialog(QWidget):
         """Get list of selected band names."""
         return [item.text() for item in self.band_list.selectedItems()]
 
+    def _populate_band_list(self, bands, selected_bands=None):
+        """Populate band list, preserving selection when provided.
+
+        Args:
+            bands: Available band names.
+            selected_bands: Previously selected band names. ``None`` means this
+                is an initial load and all available bands should be selected.
+                An empty set means the user cleared selection and it should stay
+                empty.
+        """
+        select_all = selected_bands is None
+        selected_bands = set(selected_bands or [])
+
+        self.band_list.blockSignals(True)
+        try:
+            self.band_list.clear()
+            for band in bands:
+                item = QListWidgetItem(band)
+                self.band_list.addItem(item)
+                item.setSelected(select_all or band in selected_bands)
+        finally:
+            self.band_list.blockSignals(False)
+
+    def _on_band_selection_changed(self):
+        """Refresh chart and statistics when selected bands change."""
+        self._update_chart()
+        self._update_stats()
+
+    def _clear_selected_bands(self):
+        """Clear all selected bands from the chart."""
+        self.band_list.blockSignals(True)
+        try:
+            for index in range(self.band_list.count()):
+                self.band_list.item(index).setSelected(False)
+        finally:
+            self.band_list.blockSignals(False)
+        self._on_band_selection_changed()
+
+    def _clear_chart_display(self, message="No bands selected."):
+        """Clear the chart area and show a short empty-state message."""
+        if self._has_matplotlib:
+            self.figure.clear()
+            ax = self.figure.add_subplot(111)
+            ax.text(0.5, 0.5, message, ha="center", va="center", transform=ax.transAxes)
+            ax.set_axis_off()
+            self.canvas.draw()
+        elif hasattr(self, "text_display"):
+            self.text_display.setText(message)
+
+    @staticmethod
+    def _band_color_map(bands, plt):
+        """Return deterministic, visually distinct colors keyed by band name."""
+        if not bands:
+            return {}
+        cmap = plt.get_cmap("tab20" if len(bands) > 10 else "tab10")
+        return {band: cmap(index % cmap.N) for index, band in enumerate(bands)}
+
     def _update_chart(self):
         """Update the chart with current data and options."""
         if self._is_multi_location and self._multi_data:
@@ -1577,6 +1638,7 @@ class TimeSeriesChartDialog(QWidget):
         elif self._data:
             selected_bands = self._get_selected_bands()
             if not selected_bands:
+                self._clear_chart_display()
                 return
 
             dates = self._data.get("dates", [])
@@ -1594,6 +1656,7 @@ class TimeSeriesChartDialog(QWidget):
 
         selected_bands = self._get_selected_bands()
         if not selected_bands:
+            self._clear_chart_display()
             return
 
         from datetime import datetime
@@ -1601,6 +1664,7 @@ class TimeSeriesChartDialog(QWidget):
         import matplotlib.dates as mdates
 
         self.figure.clear()
+        band_colors = self._band_color_map(selected_bands, plt)
 
         # Check if stacked (subplots) mode
         if self.stack_lines_check.isChecked() and len(selected_bands) > 1:
@@ -1612,7 +1676,7 @@ class TimeSeriesChartDialog(QWidget):
 
             for band_idx, (band, ax) in enumerate(zip(selected_bands, axes)):
                 # Plot each location for this band
-                for loc_id, data in self._multi_data.items():
+                for loc_idx, (loc_id, data) in enumerate(self._multi_data.items()):
                     dates = data.get("dates", [])
                     values = data.get("values", {})
                     metadata = data.get("metadata", {})
@@ -1638,24 +1702,16 @@ class TimeSeriesChartDialog(QWidget):
 
                     valid_dates, valid_values = zip(*valid_points)
 
-                    # Get color from location
-                    color = data.get("location_color")
-                    if color:
-                        color = (
-                            color.red() / 255,
-                            color.green() / 255,
-                            color.blue() / 255,
-                        )
-                    else:
-                        color = plt.cm.tab10.colors[loc_id % 10]
+                    color = band_colors.get(band, plt.cm.tab10.colors[band_idx % 10])
 
                     label = f"Loc {loc_id} ({metadata.get('lon', 0):.2f}, {metadata.get('lat', 0):.2f})"
 
                     if self.interpolate_check.isChecked():
+                        linestyle = ["-", "--", ":", "-."][loc_idx % 4]
                         ax.plot(
                             valid_dates,
                             valid_values,
-                            "-",
+                            linestyle,
                             color=color,
                             label=label,
                             linewidth=1.5,
@@ -1681,7 +1737,7 @@ class TimeSeriesChartDialog(QWidget):
             # Single plot with all bands and locations
             ax = self.figure.add_subplot(111)
 
-            for loc_id, data in self._multi_data.items():
+            for loc_idx, (loc_id, data) in enumerate(self._multi_data.items()):
                 dates = data.get("dates", [])
                 values = data.get("values", {})
                 metadata = data.get("metadata", {})
@@ -1691,17 +1747,6 @@ class TimeSeriesChartDialog(QWidget):
                     date_objects = [datetime.strptime(d, "%Y-%m-%d") for d in dates]
                 except Exception:
                     date_objects = list(range(len(dates)))
-
-                # Get base color from location
-                base_color = data.get("location_color")
-                if base_color:
-                    base_rgb = (
-                        base_color.red() / 255,
-                        base_color.green() / 255,
-                        base_color.blue() / 255,
-                    )
-                else:
-                    base_rgb = plt.cm.tab10.colors[loc_id % 10]
 
                 for band_idx, band in enumerate(selected_bands):
                     band_values = values.get(band, [])
@@ -1719,13 +1764,12 @@ class TimeSeriesChartDialog(QWidget):
 
                     valid_dates, valid_values = zip(*valid_points)
 
-                    # Vary color slightly for different bands at same location
-                    color = base_rgb
+                    color = band_colors.get(band, plt.cm.tab10.colors[band_idx % 10])
 
                     label = f"Loc {loc_id} - {band}"
 
                     if self.interpolate_check.isChecked():
-                        linestyle = ["-", "--", ":", "-."][band_idx % 4]
+                        linestyle = ["-", "--", ":", "-."][loc_idx % 4]
                         ax.plot(
                             valid_dates,
                             valid_values,
@@ -1767,7 +1811,6 @@ class TimeSeriesChartDialog(QWidget):
         from datetime import datetime
         import matplotlib.pyplot as plt
         import matplotlib.dates as mdates
-        import random
 
         self.figure.clear()
 
@@ -1780,14 +1823,7 @@ class TimeSeriesChartDialog(QWidget):
         metadata = self._data.get("metadata", {})
         asset_id = metadata.get("asset_id", "").split("/")[-1]
 
-        # Generate visually distinct, deterministic colors for each band.
-        # random is seeded with a constant; this is for visualization only,
-        # not for any security or cryptographic purpose.
-        random.seed(42)
-        colors = [
-            (random.random(), random.random(), random.random())  # nosec B311
-            for _ in range(len(selected_bands))
-        ]
+        colors = self._band_color_map(selected_bands, plt)
 
         # Check if stacked (subplots) mode
         if self.stack_lines_check.isChecked() and len(selected_bands) > 1:
@@ -1811,7 +1847,7 @@ class TimeSeriesChartDialog(QWidget):
                     continue
 
                 valid_dates, valid_values = zip(*valid_points)
-                color = colors[i]
+                color = colors.get(band, plt.cm.tab10.colors[i % 10])
 
                 # Plot line if interpolate is checked
                 if self.interpolate_check.isChecked():
@@ -1853,7 +1889,7 @@ class TimeSeriesChartDialog(QWidget):
                     continue
 
                 valid_dates, valid_values = zip(*valid_points)
-                color = colors[i]
+                color = colors.get(band, plt.cm.tab10.colors[i % 10])
 
                 # Plot line if interpolate is checked
                 if self.interpolate_check.isChecked():
@@ -2354,6 +2390,8 @@ class PixelTimeSeriesMapTool:
                 self.setCursor(Qt.CursorShape.CrossCursor)
 
             def canvasReleaseEvent(self, event):
+                if not callable(self.callback):
+                    return
                 # Get click coordinates
                 point = self.toMapCoordinates(event.pos())
 
@@ -2410,6 +2448,8 @@ class InspectorMapTool:
                 self.setCursor(Qt.CursorShape.CrossCursor)
 
             def canvasReleaseEvent(self, event):
+                if not callable(self.callback):
+                    return
                 # Get click coordinates
                 point = self.toMapCoordinates(event.pos())
 
@@ -2429,7 +2469,14 @@ class InspectorMapTool:
                     )
                     point = transform.transform(point)
 
-                self.callback(point.x(), point.y())
+                try:
+                    self.callback(point.x(), point.y())
+                except RuntimeError as exc:
+                    QgsMessageLog.logMessage(
+                        f"Ignoring Inspector click after dock cleanup: {exc}",
+                        "GEE Data Catalogs",
+                        Qgis.MessageLevel.Warning,
+                    )
 
         self.tool = ClickTool(iface.mapCanvas(), inspector_callback)
 
@@ -2443,7 +2490,10 @@ class InspectorMapTool:
         """Deactivate the map tool."""
         from qgis.utils import iface
 
-        iface.mapCanvas().unsetMapTool(self.tool)
+        try:
+            iface.mapCanvas().unsetMapTool(self.tool)
+        finally:
+            self.tool.callback = None
 
 
 class CatalogDockWidget(QDockWidget):
@@ -2465,13 +2515,19 @@ class CatalogDockWidget(QDockWidget):
         self._image_list_thread = None
         self._preview_thread = None
         self._thumbnail_thread = None
+        self._saved_thumbnail_thread = None
         self._current_collection = None
         self._filtered_collection = None
         self._current_info_html = ""
+        self._saved_info_html = ""
         self._inspector_thread = None
         self._inspector_map_tool = None
         self._inspector_active = False
+        self._inspector_shutting_down = False
         self._js_code_cache = None  # Cache for f.json JavaScript code snippets
+        self._export_queue = []
+        self._current_export_job = None
+        self._running_export_queue = False
 
         # Time series related attributes
         self._timeseries_thread = None
@@ -2551,6 +2607,14 @@ class CatalogDockWidget(QDockWidget):
         self.search_tab = self._create_search_tab()
         self.tab_widget.addTab(self.search_tab, "Search")
 
+        # Favorites / Recents tab
+        self.favorites_tab = self._create_favorites_tab()
+        self.tab_widget.addTab(self.favorites_tab, "Favorites")
+
+        # Recipes tab
+        self.recipes_tab = self._create_recipes_tab()
+        self.tab_widget.addTab(self.recipes_tab, "Recipes")
+
         # Time Series tab
         self.timeseries_tab = self._create_timeseries_tab()
         self.tab_widget.addTab(self.timeseries_tab, "Time Series")
@@ -2570,6 +2634,10 @@ class CatalogDockWidget(QDockWidget):
         # Inspector tab
         self.inspector_tab = self._create_inspector_tab()
         self.tab_widget.addTab(self.inspector_tab, "Inspector")
+
+        # Project reproducibility tab
+        self.project_tab = self._create_project_tab()
+        self.tab_widget.addTab(self.project_tab, "Project")
 
         # Export tab
         self.export_tab = self._create_export_tab()
@@ -2965,6 +3033,37 @@ class CatalogDockWidget(QDockWidget):
             return self._load_drawn_bbox
         return None
 
+    def _configure_tree_columns(
+        self,
+        tree,
+        stretch_column=0,
+        resize_to_contents=None,
+        initial_widths=None,
+        min_width=80,
+    ):
+        """Configure QTreeWidget columns for readable tab layouts."""
+        resize_to_contents = set(resize_to_contents or [])
+        initial_widths = initial_widths or {}
+        header = tree.header()
+        resize_mode = getattr(QHeaderView, "ResizeMode", QHeaderView)
+        header.setStretchLastSection(False)
+        header.setMinimumSectionSize(min_width)
+
+        stretch_mode = getattr(resize_mode, "Stretch")
+        resize_contents_mode = getattr(resize_mode, "ResizeToContents")
+        interactive_mode = getattr(resize_mode, "Interactive")
+        for column in range(tree.columnCount()):
+            if column == stretch_column:
+                mode = stretch_mode
+            elif column in resize_to_contents:
+                mode = resize_contents_mode
+            else:
+                mode = interactive_mode
+            header.setSectionResizeMode(column, mode)
+
+        for column, width in initial_widths.items():
+            tree.setColumnWidth(column, width)
+
     def _create_browse_tab(self):
         """Create the browse tab with category tree."""
         widget = QWidget()
@@ -2988,10 +3087,13 @@ class CatalogDockWidget(QDockWidget):
         # Category tree
         self.catalog_tree = QTreeWidget()
         self.catalog_tree.setHeaderLabels(["Dataset", "Type", "Source"])
+        self._configure_tree_columns(
+            self.catalog_tree,
+            stretch_column=0,
+            resize_to_contents=[1, 2],
+            initial_widths={0: 320, 1: 120, 2: 100},
+        )
         self.catalog_tree.setAlternatingRowColors(True)
-        self.catalog_tree.setColumnWidth(0, 220)
-        self.catalog_tree.setColumnWidth(1, 100)
-        self.catalog_tree.setColumnWidth(2, 80)
         self.catalog_tree.itemClicked.connect(self._on_dataset_selected)
         self.catalog_tree.itemDoubleClicked.connect(self._on_dataset_double_clicked)
         splitter.addWidget(self.catalog_tree)
@@ -3017,6 +3119,11 @@ class CatalogDockWidget(QDockWidget):
         self.configure_btn.setEnabled(False)
         self.configure_btn.clicked.connect(self._configure_and_add)
         btn_layout.addWidget(self.configure_btn)
+
+        self.favorite_btn = QPushButton("★ Favorite")
+        self.favorite_btn.setEnabled(False)
+        self.favorite_btn.clicked.connect(self._favorite_current_dataset)
+        btn_layout.addWidget(self.favorite_btn)
 
         info_layout.addLayout(btn_layout)
 
@@ -3085,9 +3192,14 @@ class CatalogDockWidget(QDockWidget):
 
         # Results
         self.search_results = QTreeWidget()
-        self.search_results.setHeaderLabels(["Dataset", "Type", "Source"])
+        self.search_results.setHeaderLabels(["Dataset", "Type", "Source", "Score"])
+        self._configure_tree_columns(
+            self.search_results,
+            stretch_column=0,
+            resize_to_contents=[1, 2, 3],
+            initial_widths={0: 320, 1: 120, 2: 100, 3: 80},
+        )
         self.search_results.setAlternatingRowColors(True)
-        self.search_results.setColumnWidth(0, 200)
         self.search_results.itemClicked.connect(self._on_search_result_selected)
         self.search_results.itemDoubleClicked.connect(
             self._on_search_result_double_clicked
@@ -3117,6 +3229,10 @@ class CatalogDockWidget(QDockWidget):
         self.search_configure_btn.clicked.connect(self._configure_search_result)
         search_btn_layout.addWidget(self.search_configure_btn)
 
+        self.search_favorite_btn = QPushButton("★ Favorite")
+        self.search_favorite_btn.clicked.connect(self._favorite_current_dataset)
+        search_btn_layout.addWidget(self.search_favorite_btn)
+
         search_info_layout.addLayout(search_btn_layout)
 
         # Second row of buttons for Time Series
@@ -3134,6 +3250,153 @@ class CatalogDockWidget(QDockWidget):
 
         splitter.setSizes([250, 250])
 
+        return widget
+
+    def _create_favorites_tab(self):
+        """Create the favorites and recent datasets tab."""
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+
+        tabs = QTabWidget()
+        layout.addWidget(tabs)
+
+        favorites_widget = QWidget()
+        favorites_layout = QVBoxLayout(favorites_widget)
+        self.favorites_tree = QTreeWidget()
+        self.favorites_tree.setHeaderLabels(["Dataset", "Type", "Source"])
+        self._configure_tree_columns(
+            self.favorites_tree,
+            stretch_column=0,
+            resize_to_contents=[1, 2],
+            initial_widths={0: 320, 1: 120, 2: 100},
+        )
+        self.favorites_tree.setAlternatingRowColors(True)
+        self.favorites_tree.itemClicked.connect(self._on_saved_dataset_selected)
+        self.favorites_tree.itemDoubleClicked.connect(
+            self._on_saved_dataset_double_clicked
+        )
+        self.favorites_tree.installEventFilter(self)
+        favorites_layout.addWidget(self.favorites_tree)
+        tabs.addTab(favorites_widget, "Favorites")
+
+        recents_widget = QWidget()
+        recents_layout = QVBoxLayout(recents_widget)
+        self.recents_tree = QTreeWidget()
+        self.recents_tree.setHeaderLabels(["Dataset", "Type", "Last Action"])
+        self._configure_tree_columns(
+            self.recents_tree,
+            stretch_column=0,
+            resize_to_contents=[1, 2],
+            initial_widths={0: 320, 1: 120, 2: 130},
+        )
+        self.recents_tree.setAlternatingRowColors(True)
+        self.recents_tree.itemClicked.connect(self._on_saved_dataset_selected)
+        self.recents_tree.itemDoubleClicked.connect(
+            self._on_saved_dataset_double_clicked
+        )
+        recents_layout.addWidget(self.recents_tree)
+        tabs.addTab(recents_widget, "Recent")
+
+        self.saved_dataset_info = QTextBrowser()
+        self.saved_dataset_info.setOpenExternalLinks(True)
+        self.saved_dataset_info.setPlaceholderText("Select a saved dataset...")
+        layout.addWidget(self.saved_dataset_info)
+
+        btn_layout = QHBoxLayout()
+        self.saved_add_btn = QPushButton("Add to Map")
+        self.saved_add_btn.clicked.connect(self._add_saved_dataset_to_map)
+        btn_layout.addWidget(self.saved_add_btn)
+
+        self.saved_configure_btn = QPushButton("Configure")
+        self.saved_configure_btn.clicked.connect(self._configure_saved_dataset)
+        btn_layout.addWidget(self.saved_configure_btn)
+
+        self.saved_timeseries_btn = QPushButton("📈 Time Series")
+        self.saved_timeseries_btn.setEnabled(False)
+        self.saved_timeseries_btn.setToolTip(
+            "Configure and create time series from this saved dataset"
+        )
+        self.saved_timeseries_btn.clicked.connect(self._configure_saved_timeseries)
+        btn_layout.addWidget(self.saved_timeseries_btn)
+
+        self.saved_remove_btn = QPushButton("Remove Favorite")
+        self.saved_remove_btn.setEnabled(False)
+        self.saved_remove_btn.setToolTip(
+            "Select a dataset in Favorites, then click to remove it."
+        )
+        self.saved_remove_btn.clicked.connect(self._remove_selected_favorite)
+        btn_layout.addWidget(self.saved_remove_btn)
+
+        refresh_btn = QPushButton("Refresh")
+        refresh_btn.clicked.connect(self._refresh_saved_datasets)
+        btn_layout.addWidget(refresh_btn)
+        layout.addLayout(btn_layout)
+
+        self._saved_dataset = None
+        self._saved_dataset_is_favorite = False
+        self._refresh_saved_datasets()
+        return widget
+
+    def _create_recipes_tab(self):
+        """Create a tab with reusable Earth Engine workflow recipes."""
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+
+        self.recipe_tree = QTreeWidget()
+        self.recipe_tree.setHeaderLabels(["Recipe", "Category", "Target"])
+        self._configure_tree_columns(
+            self.recipe_tree,
+            stretch_column=0,
+            resize_to_contents=[1, 2],
+            initial_widths={0: 420, 1: 180, 2: 90},
+        )
+        self.recipe_tree.setAlternatingRowColors(True)
+        self.recipe_tree.itemClicked.connect(self._on_recipe_selected)
+        self.recipe_tree.itemDoubleClicked.connect(self._apply_selected_recipe)
+        layout.addWidget(self.recipe_tree)
+
+        self.recipe_info = QTextBrowser()
+        self.recipe_info.setPlaceholderText("Select a recipe...")
+        layout.addWidget(self.recipe_info)
+
+        btn_layout = QHBoxLayout()
+        apply_btn = QPushButton("Apply Recipe")
+        apply_btn.clicked.connect(self._apply_selected_recipe)
+        btn_layout.addWidget(apply_btn)
+
+        code_btn = QPushButton("Copy Code")
+        code_btn.clicked.connect(self._copy_selected_recipe_code)
+        btn_layout.addWidget(code_btn)
+        layout.addLayout(btn_layout)
+
+        self._selected_recipe = None
+        self._populate_recipes()
+        return widget
+
+    def _create_project_tab(self):
+        """Create a reproducibility snapshot tab for current project state."""
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+
+        self.project_snapshot_text = QTextBrowser()
+        self.project_snapshot_text.setOpenExternalLinks(True)
+        layout.addWidget(self.project_snapshot_text)
+
+        btn_layout = QHBoxLayout()
+        refresh_btn = QPushButton("Refresh")
+        refresh_btn.clicked.connect(self._refresh_project_snapshot)
+        btn_layout.addWidget(refresh_btn)
+
+        copy_btn = QPushButton("Copy Markdown")
+        copy_btn.clicked.connect(self._copy_project_snapshot)
+        btn_layout.addWidget(copy_btn)
+
+        ai_btn = QPushButton("Open AI with Context")
+        ai_btn.clicked.connect(self._open_ai_with_project_context)
+        btn_layout.addWidget(ai_btn)
+        layout.addLayout(btn_layout)
+
+        QTimer.singleShot(0, self._refresh_project_snapshot)
         return widget
 
     def _create_timeseries_tab(self):
@@ -4604,9 +4867,13 @@ class CatalogDockWidget(QDockWidget):
 
         self.inspector_tree = QTreeWidget()
         self.inspector_tree.setHeaderLabels(["Property", "Value"])
+        self._configure_tree_columns(
+            self.inspector_tree,
+            stretch_column=1,
+            resize_to_contents=[0],
+            initial_widths={0: 220, 1: 320},
+        )
         self.inspector_tree.setAlternatingRowColors(True)
-        self.inspector_tree.setColumnWidth(0, 200)
-        self.inspector_tree.header().setStretchLastSection(True)
         layout.addWidget(self.inspector_tree)
 
         # Progress bar
@@ -4795,6 +5062,14 @@ class CatalogDockWidget(QDockWidget):
         self.export_btn.setStyleSheet("font-weight: bold;")
         btn_layout.addWidget(self.export_btn)
 
+        queue_btn = QPushButton("Add to Queue")
+        queue_btn.clicked.connect(self._add_export_to_queue)
+        btn_layout.addWidget(queue_btn)
+
+        run_queue_btn = QPushButton("Run Queue")
+        run_queue_btn.clicked.connect(self._run_export_queue)
+        btn_layout.addWidget(run_queue_btn)
+
         layout.addLayout(btn_layout)
 
         # Progress bar
@@ -4808,12 +5083,17 @@ class CatalogDockWidget(QDockWidget):
         self.export_status_label.setStyleSheet("color: gray; font-size: 10px;")
         layout.addWidget(self.export_status_label)
 
+        self.export_history_list = QListWidget()
+        self.export_history_list.setMaximumHeight(110)
+        layout.addWidget(self.export_history_list)
+
         # Add stretch to push everything up
         layout.addStretch()
 
         # Initialize layer lists
         self._refresh_export_layers()
         self._refresh_vector_layers()
+        self._refresh_export_history()
 
         return widget
 
@@ -5151,14 +5431,100 @@ class CatalogDockWidget(QDockWidget):
             QgsGeometry.fromPolygonXY([points]), None
         )
 
-    def _do_export(self):
-        """Perform the export operation using a background thread."""
-        from ..core.ee_utils import get_ee_layers
-
+    def _collect_export_job(self):
+        """Collect current export UI settings into a serializable job."""
         layer_name = self.export_layer_combo.currentText()
         if layer_name.startswith("--"):
             QMessageBox.warning(self, "Error", "Please select a valid EE layer.")
+            return None
+        return {
+            "layer_name": layer_name,
+            "scale": self.export_scale_spin.value(),
+            "crs": self.export_crs_edit.text().strip() or "EPSG:3857",
+            "vector_format": self.export_format_combo.currentText(),
+            "output_path": self.export_output_edit.text().strip(),
+            "region_mode": self.export_region_btn_group.checkedId(),
+            "custom_bounds": self.export_bounds_edit.text().strip(),
+            "drawn_bounds": self._export_drawn_bounds,
+            "vector_layer": self.export_vector_combo.currentText(),
+        }
+
+    def _add_export_to_queue(self):
+        job = self._collect_export_job()
+        if not job:
             return
+        self._export_queue.append(job)
+        self._refresh_export_history()
+        self.export_status_label.setText(
+            f"Queued {len(self._export_queue)} export job(s)."
+        )
+
+    def _run_export_queue(self):
+        if not self._export_queue:
+            self.export_status_label.setText("Export queue is empty.")
+            return
+        if (
+            getattr(self, "_export_thread", None) is not None
+            and self._export_thread.isRunning()
+        ):
+            self.export_status_label.setText("An export is already running.")
+            return
+        self._running_export_queue = True
+        self._run_next_export_job()
+
+    def _run_next_export_job(self):
+        if not self._export_queue:
+            self._running_export_queue = False
+            self._current_export_job = None
+            self.export_status_label.setText("Export queue complete.")
+            return
+        job = self._export_queue.pop(0)
+        self._apply_export_job_to_ui(job)
+        self._do_export(from_queue=True)
+
+    def _apply_export_job_to_ui(self, job):
+        index = self.export_layer_combo.findText(job.get("layer_name", ""))
+        if index >= 0:
+            self.export_layer_combo.setCurrentIndex(index)
+        self.export_scale_spin.setValue(int(job.get("scale", 30)))
+        self.export_crs_edit.setText(job.get("crs", "EPSG:3857"))
+        fmt_index = self.export_format_combo.findText(
+            job.get("vector_format", "GeoJSON")
+        )
+        if fmt_index >= 0:
+            self.export_format_combo.setCurrentIndex(fmt_index)
+        self.export_output_edit.setText(job.get("output_path", ""))
+        region_mode = int(job.get("region_mode", 0))
+        button = self.export_region_btn_group.button(region_mode)
+        if button:
+            button.setChecked(True)
+        self.export_bounds_edit.setText(job.get("custom_bounds", ""))
+        self._export_drawn_bounds = job.get("drawn_bounds")
+
+    def _refresh_export_history(self):
+        """Render queued jobs and persisted export history."""
+        if not hasattr(self, "export_history_list"):
+            return
+        from ..core.user_state import get_export_history
+
+        self.export_history_list.clear()
+        for idx, job in enumerate(self._export_queue, start=1):
+            self.export_history_list.addItem(
+                f"Queued {idx}: {job.get('layer_name', '')} -> {job.get('output_path') or '(temporary)'}"
+            )
+        for job in get_export_history()[:10]:
+            self.export_history_list.addItem(
+                f"{job.get('status', '')}: {job.get('layer_name', '')} -> {job.get('output_path', '')}"
+            )
+
+    def _do_export(self, from_queue=False):
+        """Perform the export operation using a background thread."""
+        from ..core.ee_utils import get_ee_layers
+
+        job = self._collect_export_job()
+        if not job:
+            return
+        layer_name = job["layer_name"]
 
         ee_layers = get_ee_layers()
         if layer_name not in ee_layers:
@@ -5173,9 +5539,9 @@ class CatalogDockWidget(QDockWidget):
             return
 
         # Get options
-        scale = self.export_scale_spin.value()
-        crs = self.export_crs_edit.text().strip() or "EPSG:3857"
-        vector_format = self.export_format_combo.currentText()
+        scale = job["scale"]
+        crs = job["crs"]
+        vector_format = job["vector_format"]
 
         # Determine export type
         type_name = type(ee_object).__name__
@@ -5197,12 +5563,16 @@ class CatalogDockWidget(QDockWidget):
             QMessageBox.warning(self, "Error", f"Unsupported object type: {type_name}")
             return
 
-        output_path = self.export_output_edit.text().strip()
+        output_path = job.get("output_path", "")
         if not output_path:
             output_path = self._generate_temp_export_path(
                 export_type=export_type, vector_format=vector_format
             )
             self.export_output_edit.setText(output_path)
+        job["output_path"] = output_path
+        job["export_type"] = export_type
+        job["from_queue"] = from_queue
+        self._current_export_job = job
 
         # Show progress
         self._start_export_progress()
@@ -5237,14 +5607,22 @@ class CatalogDockWidget(QDockWidget):
         self.export_btn.setEnabled(True)
         self.export_status_label.setText(f"Exported to: {output_path}")
         self.export_status_label.setStyleSheet("color: green; font-size: 10px;")
+        if self._current_export_job:
+            from ..core.user_state import record_export_job
+
+            self._current_export_job["output_path"] = output_path
+            record_export_job(self._current_export_job, "success", output_path)
+            self._refresh_export_history()
 
         # Ask if user wants to add to map
-        reply = QMessageBox.question(
-            self,
-            "Export Complete",
-            f"Export successful!\n{output_path}\n\nAdd layer to map?",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-        )
+        reply = QMessageBox.StandardButton.No
+        if not self._running_export_queue:
+            reply = QMessageBox.question(
+                self,
+                "Export Complete",
+                f"Export successful!\n{output_path}\n\nAdd layer to map?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            )
         if reply == QMessageBox.StandardButton.Yes:
             layer_name = os.path.splitext(os.path.basename(output_path))[0]
             if output_path.lower().endswith(".tif"):
@@ -5258,6 +5636,8 @@ class CatalogDockWidget(QDockWidget):
 
             if layer.isValid():
                 QgsProject.instance().addMapLayer(layer)
+        if self._running_export_queue:
+            QTimer.singleShot(0, self._run_next_export_job)
 
     def _on_export_error(self, error_message):
         """Handle export error."""
@@ -5265,7 +5645,14 @@ class CatalogDockWidget(QDockWidget):
         self.export_btn.setEnabled(True)
         self.export_status_label.setText("Export failed!")
         self.export_status_label.setStyleSheet("color: red; font-size: 10px;")
+        if self._current_export_job:
+            from ..core.user_state import record_export_job
+
+            record_export_job(self._current_export_job, "error", error_message)
+            self._refresh_export_history()
         QMessageBox.critical(self, "Export Error", f"Export failed:\n{error_message}")
+        if self._running_export_queue:
+            QTimer.singleShot(0, self._run_next_export_job)
 
     def _start_export_progress(self):
         """Start an indeterminate progress indicator for export."""
@@ -5567,10 +5954,26 @@ class CatalogDockWidget(QDockWidget):
         elif current_widget == getattr(self, "export_tab", None):
             self._refresh_export_layers()
             self._refresh_vector_layers()
+            self._refresh_export_history()
+        elif current_widget == getattr(self, "favorites_tab", None):
+            self._refresh_saved_datasets()
+        elif current_widget == getattr(self, "project_tab", None):
+            self._refresh_project_snapshot()
 
         plugin = getattr(self, "plugin", None)
         if plugin is not None and hasattr(plugin, "_sync_panel_actions"):
             plugin._sync_panel_actions()
+
+    def eventFilter(self, obj, event):
+        """Handle keyboard shortcuts for dock child widgets."""
+        key_press = getattr(getattr(QEvent, "Type", QEvent), "KeyPress")
+        if obj is getattr(self, "favorites_tree", None) and event.type() == key_press:
+            delete_key = getattr(getattr(Qt, "Key", Qt), "Key_Delete")
+            backspace_key = getattr(getattr(Qt, "Key", Qt), "Key_Backspace")
+            if event.key() in {delete_key, backspace_key}:
+                self._remove_selected_favorite()
+                return True
+        return super().eventFilter(obj, event)
 
     def show_ai_assistant_tab(self):
         """Backward-compatible entry point for opening OpenGeoAgent chat."""
@@ -5592,6 +5995,365 @@ class CatalogDockWidget(QDockWidget):
             and self._selected_dataset.get("id") != asset_id.strip()
         ):
             self._selected_dataset = None
+
+    def _saved_dataset_item(self, dataset):
+        """Create a tree item for a favorite/recent dataset."""
+        item = QTreeWidgetItem(
+            [
+                dataset.get("name", dataset.get("id", "Unknown"))[:55],
+                dataset.get("type", "Unknown"),
+                dataset.get("source", dataset.get("last_action", "")),
+            ]
+        )
+        item.setData(0, Qt.ItemDataRole.UserRole, dataset)
+        item.setToolTip(0, dataset.get("id", ""))
+        return item
+
+    def _refresh_saved_datasets(self):
+        """Reload favorites and recents from settings."""
+        try:
+            from ..core.user_state import get_favorites, get_recents
+
+            self.favorites_tree.clear()
+            for dataset in get_favorites():
+                self.favorites_tree.addTopLevelItem(self._saved_dataset_item(dataset))
+
+            self.recents_tree.clear()
+            for dataset in get_recents():
+                item = QTreeWidgetItem(
+                    [
+                        dataset.get("name", dataset.get("id", "Unknown"))[:55],
+                        dataset.get("type", "Unknown"),
+                        dataset.get("last_action", ""),
+                    ]
+                )
+                item.setData(0, Qt.ItemDataRole.UserRole, dataset)
+                item.setToolTip(0, dataset.get("id", ""))
+                self.recents_tree.addTopLevelItem(item)
+            if self._saved_dataset and not any(
+                item.get("id") == self._saved_dataset.get("id")
+                for item in get_favorites()
+            ):
+                self._saved_dataset_is_favorite = False
+                self.saved_remove_btn.setEnabled(False)
+        except Exception as exc:
+            self._show_error(f"Failed to refresh saved datasets: {exc}")
+
+    def _on_saved_dataset_selected(self, item, _column):
+        """Show details for a favorite or recent dataset."""
+        dataset = item.data(0, Qt.ItemDataRole.UserRole)
+        self._saved_dataset = dataset
+        self._saved_dataset_is_favorite = item.treeWidget() is self.favorites_tree
+        self.saved_remove_btn.setEnabled(
+            bool(dataset and self._saved_dataset_is_favorite)
+        )
+        is_image_collection = (
+            str(dataset.get("type", "")).lower() == "imagecollection"
+            if dataset
+            else False
+        )
+        self.saved_timeseries_btn.setEnabled(is_image_collection)
+        if dataset:
+            self._show_saved_dataset_info(dataset)
+
+    def _on_saved_dataset_double_clicked(self, item, _column):
+        dataset = item.data(0, Qt.ItemDataRole.UserRole)
+        if dataset:
+            self._add_dataset_to_map(dataset)
+
+    def _add_saved_dataset_to_map(self):
+        if self._saved_dataset:
+            self._add_dataset_to_map(self._saved_dataset)
+
+    def _configure_saved_dataset(self):
+        if not self._saved_dataset:
+            return
+        self._selected_dataset = self._saved_dataset
+        self._configure_and_add()
+
+    def _configure_saved_timeseries(self):
+        if not self._saved_dataset:
+            return
+        self._selected_dataset = self._saved_dataset
+        self._configure_timeseries()
+
+    def _remove_selected_favorite(self):
+        if not self._saved_dataset or not self._saved_dataset_is_favorite:
+            return
+        from ..core.user_state import remove_favorite
+
+        dataset_name = self._saved_dataset.get(
+            "name", self._saved_dataset.get("id", "dataset")
+        )
+        remove_favorite(self._saved_dataset.get("id", ""))
+        self._saved_dataset = None
+        self._saved_dataset_is_favorite = False
+        self._refresh_saved_datasets()
+        self.saved_dataset_info.clear()
+        self.saved_remove_btn.setEnabled(False)
+        self.saved_timeseries_btn.setEnabled(False)
+        self._show_success(f"Removed favorite: {dataset_name}")
+
+    def _favorite_current_dataset(self):
+        """Add the currently selected dataset to Favorites."""
+        if not self._selected_dataset:
+            return
+        from ..core.user_state import add_favorite
+
+        add_favorite(self._selected_dataset)
+        self._refresh_saved_datasets()
+        self._show_success("Added dataset to Favorites.")
+
+    def _dataset_info_html(self, dataset):
+        """Return compact dataset details as HTML."""
+        source_badge = (
+            f"<span style='background-color: {'#4285F4' if dataset.get('source') == 'official' else '#34A853'}; "
+            f"color: white; padding: 2px 6px; border-radius: 3px; font-size: 10px;'>"
+            f"{dataset.get('source', 'unknown').upper()}</span>"
+        )
+        info_lines = [
+            source_badge,
+            f"<b>Name:</b> {dataset.get('name', dataset.get('title', 'Unknown'))}",
+            f"<b>ID:</b> <code>{dataset.get('id', 'Unknown')}</code>",
+            f"<b>Type:</b> {dataset.get('type', 'Unknown')}",
+            f"<b>Provider:</b> {dataset.get('provider', 'Unknown')}",
+        ]
+        if dataset.get("_search_score") is not None:
+            info_lines.append(f"<b>Search score:</b> {dataset.get('_search_score')}")
+        if dataset.get("thumbnail"):
+            info_lines.append(
+                "<div id='saved-thumbnail-placeholder'><i>Loading thumbnail...</i></div>"
+            )
+        if dataset.get("description"):
+            info_lines.append(
+                f"<b>Description:</b><br>{dataset.get('description', '')[:500]}..."
+            )
+        if dataset.get("start_date"):
+            info_lines.append(f"<b>Start Date:</b> {dataset['start_date']}")
+        if dataset.get("end_date"):
+            info_lines.append(f"<b>End Date:</b> {dataset['end_date']}")
+        for label, key in (("URL", "url"), ("Docs", "docs"), ("Script", "script")):
+            if dataset.get(key):
+                value = dataset[key]
+                info_lines.append(f"<b>{label}:</b> <a href='{value}'>{value}</a>")
+        return "<br>".join(info_lines)
+
+    def _show_saved_dataset_info(self, dataset):
+        """Render favorite/recent dataset details and load its thumbnail."""
+        if self._saved_thumbnail_thread and self._saved_thumbnail_thread.isRunning():
+            self._saved_thumbnail_thread.terminate()
+            self._saved_thumbnail_thread.wait()
+
+        self._saved_info_html = self._dataset_info_html(dataset)
+        self.saved_dataset_info.setHtml(self._saved_info_html)
+
+        thumbnail_url = dataset.get("thumbnail", "")
+        if thumbnail_url:
+            self._saved_thumbnail_thread = ThumbnailLoaderThread(thumbnail_url)
+            self._saved_thumbnail_thread.finished.connect(
+                self._on_saved_thumbnail_loaded
+            )
+            self._saved_thumbnail_thread.error.connect(self._on_saved_thumbnail_error)
+            self._saved_thumbnail_thread.start()
+
+    def _on_saved_thumbnail_loaded(self, img_data_url):
+        """Handle favorite/recent thumbnail loaded successfully."""
+        thumbnail_html = (
+            f"<br><img src='{img_data_url}' width='300' "
+            "style='border: 1px solid #ccc; border-radius: 4px;'><br>"
+        )
+        self._saved_info_html = self._saved_info_html.replace(
+            "<div id='saved-thumbnail-placeholder'><i>Loading thumbnail...</i></div>",
+            thumbnail_html,
+        )
+        self.saved_dataset_info.setHtml(self._saved_info_html)
+
+    def _on_saved_thumbnail_error(self, _error):
+        """Remove favorite/recent thumbnail placeholder if loading fails."""
+        self._saved_info_html = self._saved_info_html.replace(
+            "<div id='saved-thumbnail-placeholder'><i>Loading thumbnail...</i></div>",
+            "",
+        )
+        self.saved_dataset_info.setHtml(self._saved_info_html)
+
+    def _populate_recipes(self):
+        """Populate the recipes tree."""
+        from ..core.user_state import get_recipes
+
+        self.recipe_tree.clear()
+        for recipe in get_recipes():
+            item = QTreeWidgetItem(
+                [
+                    recipe.get("name", "Unnamed recipe"),
+                    recipe.get("category", ""),
+                    recipe.get("target", ""),
+                ]
+            )
+            item.setData(0, Qt.ItemDataRole.UserRole, recipe)
+            item.setToolTip(0, recipe.get("asset_id", ""))
+            self.recipe_tree.addTopLevelItem(item)
+
+    def _on_recipe_selected(self, item, _column):
+        recipe = item.data(0, Qt.ItemDataRole.UserRole)
+        self._selected_recipe = recipe
+        if not recipe:
+            return
+        self.recipe_info.setHtml(
+            "<br>".join(
+                [
+                    f"<b>{recipe.get('name', 'Recipe')}</b>",
+                    f"<b>Asset:</b> <code>{recipe.get('asset_id', '')}</code>",
+                    f"<b>Target:</b> {recipe.get('target', '')}",
+                    f"<b>Bands:</b> {recipe.get('bands', '')}",
+                    f"<b>Description:</b><br>{recipe.get('description', '')}",
+                ]
+            )
+        )
+
+    def _recipe_vis_params(self, recipe):
+        vis_params = {}
+        if recipe.get("bands"):
+            vis_params["bands"] = [
+                band.strip() for band in str(recipe["bands"]).split(",") if band.strip()
+            ]
+        for key in ("min", "max"):
+            if recipe.get(key) is not None:
+                vis_params[key] = recipe[key]
+        if recipe.get("palette"):
+            vis_params["palette"] = [
+                color.strip()
+                for color in str(recipe["palette"]).split(",")
+                if color.strip()
+            ]
+        return vis_params
+
+    def _apply_selected_recipe(self):
+        """Apply selected recipe to the Load or Time Series tab."""
+        recipe = self._selected_recipe
+        if not recipe:
+            return
+        asset_id = recipe.get("asset_id", "")
+        name = recipe.get("name", asset_id.split("/")[-1])
+        target = recipe.get("target", "load")
+        if target == "timeseries":
+            self.ts_dataset_id_input.setText(asset_id)
+            self.ts_layer_name_input.setText(name[:50])
+            if recipe.get("bands"):
+                self.ts_bands_input.setText(str(recipe.get("bands")))
+            self.tab_widget.setCurrentWidget(self.timeseries_tab)
+        else:
+            self.dataset_id_input.setText(asset_id)
+            self.layer_name_input.setText(name[:50])
+            if recipe.get("cloud_cover") is not None:
+                self.cloud_cover_spin.setValue(int(recipe["cloud_cover"]))
+            if recipe.get("bands"):
+                self.bands_input.setText(str(recipe.get("bands")))
+            if recipe.get("min") is not None:
+                self.vis_min_input.setText(str(recipe.get("min")))
+            if recipe.get("max") is not None:
+                self.vis_max_input.setText(str(recipe.get("max")))
+            if recipe.get("palette"):
+                self.palette_input.setText(str(recipe.get("palette")))
+            self.tab_widget.setCurrentWidget(self.load_tab)
+        self._show_success(f"Applied recipe: {name}")
+
+    def _selected_recipe_code(self):
+        recipe = self._selected_recipe
+        if not recipe:
+            return ""
+        asset_id = recipe.get("asset_id", "")
+        vis_params = self._recipe_vis_params(recipe)
+        constructor = (
+            "ee.ImageCollection"
+            if recipe.get("type") == "ImageCollection"
+            else "ee.Image"
+        )
+        if recipe.get("type") == "FeatureCollection":
+            constructor = "ee.FeatureCollection"
+        lines = [
+            "import ee",
+            "",
+            f"asset = {constructor}('{asset_id}')",
+        ]
+        if recipe.get("type") == "ImageCollection":
+            lines.append("image = asset.median()")
+        else:
+            lines.append("image = asset")
+        lines.extend(
+            [
+                f"vis_params = {vis_params!r}",
+                "# In QGIS, use the plugin Load tab or qgis_geemap to add this layer.",
+            ]
+        )
+        return "\n".join(lines)
+
+    def _copy_selected_recipe_code(self):
+        code = self._selected_recipe_code()
+        if not code:
+            return
+        QApplication.clipboard().setText(code)
+        self._show_success("Recipe code copied to clipboard.")
+
+    def get_ai_context_snapshot(self):
+        """Return current plugin/project state as Markdown for AI handoff."""
+        from ..core.ee_utils import get_ee_layers
+
+        lines = ["# GEE Data Catalogs Context", ""]
+        if self._selected_dataset:
+            lines.extend(
+                [
+                    "## Selected Dataset",
+                    f"- Name: {self._selected_dataset.get('name', '')}",
+                    f"- Asset ID: {self._selected_dataset.get('id', '')}",
+                    f"- Type: {self._selected_dataset.get('type', '')}",
+                    "",
+                ]
+            )
+        try:
+            extent = self._get_map_extent_wgs84()
+            if extent:
+                lines.extend(
+                    [
+                        "## Current Map Extent",
+                        f"- WGS84 bounds: {extent[0]:.6f}, {extent[1]:.6f}, {extent[2]:.6f}, {extent[3]:.6f}",
+                        "",
+                    ]
+                )
+        except Exception as exc:
+            QgsMessageLog.logMessage(
+                f"Could not include map extent in AI context: {exc}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
+            )
+        lines.append("## Earth Engine Layers")
+        ee_layers = get_ee_layers()
+        if ee_layers:
+            for name, (_ee_object, vis_params) in ee_layers.items():
+                lines.append(f"- {name}: vis={vis_params}")
+        else:
+            lines.append("- None registered")
+        lines.append("")
+        lines.append("## QGIS Layers")
+        for layer in QgsProject.instance().mapLayers().values():
+            lines.append(f"- {layer.name()} ({layer.type()})")
+        return "\n".join(lines)
+
+    def _refresh_project_snapshot(self):
+        markdown = self.get_ai_context_snapshot()
+        html_text = (
+            markdown.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        )
+        self.project_snapshot_text.setHtml(f"<pre>{html_text}</pre>")
+
+    def _copy_project_snapshot(self):
+        QApplication.clipboard().setText(self.get_ai_context_snapshot())
+        self._show_success("Project snapshot copied to clipboard.")
+
+    def _open_ai_with_project_context(self):
+        QApplication.clipboard().setText(self.get_ai_context_snapshot())
+        plugin = getattr(self, "plugin", None)
+        if plugin is not None and hasattr(plugin, "open_ai_assistant"):
+            plugin.open_ai_assistant(with_context=True)
 
     def _start_catalog_load(self):
         """Start loading catalogs in background."""
@@ -5729,6 +6491,7 @@ class CatalogDockWidget(QDockWidget):
             self._reset_vis_params()
             self.add_map_btn.setEnabled(True)
             self.configure_btn.setEnabled(True)
+            self.favorite_btn.setEnabled(True)
             # Enable time series button only for ImageCollections
             is_image_collection = dataset.get("type", "").lower() == "imagecollection"
             self.timeseries_btn.setEnabled(is_image_collection)
@@ -5739,6 +6502,7 @@ class CatalogDockWidget(QDockWidget):
             self.info_text.clear()
             self.add_map_btn.setEnabled(False)
             self.configure_btn.setEnabled(False)
+            self.favorite_btn.setEnabled(False)
             self.timeseries_btn.setEnabled(False)
 
     def _on_dataset_double_clicked(self, item, _column):
@@ -6073,6 +6837,10 @@ for f in data['features']:
             # Check if we have JavaScript code for this asset
             if self._run_js_code_for_asset(asset_id):
                 name = dataset.get("name", asset_id.split("/")[-1])[:50]
+                from ..core.user_state import record_recent_dataset
+
+                record_recent_dataset(dataset, "load")
+                self._refresh_saved_datasets()
                 self._show_success(f"Added layer: {name} (from sample code)")
                 return
 
@@ -6106,6 +6874,10 @@ for f in data['features']:
 
             # Add layer
             add_ee_layer(ee_object, vis_params, name)
+            from ..core.user_state import record_recent_dataset
+
+            record_recent_dataset(dataset, "load")
+            self._refresh_saved_datasets()
             self._show_success(f"Added layer: {name} ({actual_type})")
 
         except Exception as e:
@@ -6139,6 +6911,7 @@ for f in data['features']:
                         dataset.get("name", dataset.get("id", "Unknown"))[:50],
                         dataset.get("type", "Unknown"),
                         dataset.get("source", "unknown"),
+                        str(dataset.get("_search_score", "")),
                     ]
                 )
                 item.setData(0, Qt.ItemDataRole.UserRole, dataset)
@@ -7409,6 +8182,76 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
                 "No Earth Engine layers registered yet. Add layers using Browse/Search/Load/Code tabs."
             )
 
+    @staticmethod
+    def _qt_object_deleted(obj):
+        """Return True if a wrapped Qt object has already been deleted."""
+        if obj is None:
+            return True
+        try:
+            from qgis.PyQt import sip
+
+            return bool(sip.isdeleted(obj))
+        except Exception:
+            try:
+                obj.objectName()
+            except RuntimeError:
+                return True
+            except Exception:
+                return False
+        return False
+
+    def _inspector_ui_available(self):
+        """Return whether Inspector widgets are still safe to update."""
+        return not any(
+            self._qt_object_deleted(widget)
+            for widget in (
+                self.inspector_lon_label,
+                self.inspector_lat_label,
+                self.inspector_tree,
+                self.inspector_progress_bar,
+                self.inspector_status_label,
+                self.inspector_toggle_btn,
+            )
+        )
+
+    def _set_inspector_status(self, text, style=None):
+        """Safely update Inspector status after async callbacks."""
+        if self._inspector_shutting_down or not self._inspector_ui_available():
+            return
+        self.inspector_status_label.setText(text)
+        if style:
+            self.inspector_status_label.setStyleSheet(style)
+
+    def _shutdown_inspector(self, update_ui=True):
+        """Deactivate Inspector map tool and stop callbacks into this dock."""
+        self._inspector_shutting_down = True
+        if self._inspector_map_tool:
+            try:
+                self._inspector_map_tool.deactivate()
+            except Exception as exc:
+                QgsMessageLog.logMessage(
+                    f"Failed to deactivate Inspector map tool: {exc}",
+                    "GEE Data Catalogs",
+                    Qgis.MessageLevel.Warning,
+                )
+            self._inspector_map_tool = None
+
+        self._inspector_active = False
+
+        if (
+            update_ui
+            and not self._qt_object_deleted(getattr(self, "inspector_toggle_btn", None))
+            and not self._qt_object_deleted(
+                getattr(self, "inspector_status_label", None)
+            )
+        ):
+            self.inspector_toggle_btn.setChecked(False)
+            self.inspector_toggle_btn.setText("▶ Start Inspector")
+            self.inspector_status_label.setText("Inspector stopped.")
+            self.inspector_status_label.setStyleSheet("color: gray; font-size: 10px;")
+
+        self._inspector_shutting_down = False
+
     def _toggle_inspector(self):
         """Toggle the Inspector map tool on/off."""
         # Update layer count when starting inspector
@@ -7430,13 +8273,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
             self.inspector_status_label.setStyleSheet("color: blue; font-size: 10px;")
         else:
             # Stop inspector
-            if self._inspector_map_tool:
-                self._inspector_map_tool.deactivate()
-
-            self._inspector_active = False
-            self.inspector_toggle_btn.setText("▶ Start Inspector")
-            self.inspector_status_label.setText("Inspector stopped.")
-            self.inspector_status_label.setStyleSheet("color: gray; font-size: 10px;")
+            self._shutdown_inspector(update_ui=True)
 
     def _clear_inspector(self):
         """Clear inspector results."""
@@ -7449,9 +8286,21 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
 
     def _inspect_point(self, lon, lat):
         """Inspect Earth Engine layers at the clicked point."""
+        if not self._inspector_active or not self._inspector_ui_available():
+            return
+
         # Update location labels
-        self.inspector_lon_label.setText(f"{lon:.6f}")
-        self.inspector_lat_label.setText(f"{lat:.6f}")
+        try:
+            self.inspector_lon_label.setText(f"{lon:.6f}")
+            self.inspector_lat_label.setText(f"{lat:.6f}")
+        except RuntimeError as exc:
+            QgsMessageLog.logMessage(
+                f"Ignoring Inspector click after UI deletion: {exc}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
+            )
+            self._shutdown_inspector(update_ui=False)
+            return
 
         # Clear previous results
         self.inspector_tree.clear()
@@ -7482,14 +8331,15 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         self._inspector_thread = InspectorWorker(ee_layers, (lon, lat), int(ee_scale))
         self._inspector_thread.finished.connect(self._on_inspection_finished)
         self._inspector_thread.error.connect(self._on_inspection_error)
-        self._inspector_thread.progress.connect(
-            lambda msg: self.inspector_status_label.setText(msg)
-        )
+        self._inspector_thread.progress.connect(self._set_inspector_status)
         self._inspector_thread.start()
 
     def _on_inspection_finished(self, results):
         """Handle inspection results."""
         import json
+
+        if self._inspector_shutting_down or not self._inspector_ui_available():
+            return
 
         # Hide progress bar
         self.inspector_progress_bar.setVisible(False)
@@ -7570,6 +8420,9 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
 
     def _on_inspection_error(self, error):
         """Handle inspection error."""
+        if self._inspector_shutting_down or not self._inspector_ui_available():
+            return
+
         # Hide progress bar
         self.inspector_progress_bar.setVisible(False)
 
@@ -8945,8 +9798,7 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
     def closeEvent(self, event):
         """Handle dock widget close event."""
         # Deactivate inspector if active
-        if self._inspector_map_tool:
-            self._inspector_map_tool.deactivate()
+        self._shutdown_inspector(update_ui=False)
 
         # Stop time series playback and timer
         self._stop_timeseries_playback()
@@ -8967,6 +9819,9 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
         if self._thumbnail_thread and self._thumbnail_thread.isRunning():
             self._thumbnail_thread.terminate()
             self._thumbnail_thread.wait()
+        if self._saved_thumbnail_thread and self._saved_thumbnail_thread.isRunning():
+            self._saved_thumbnail_thread.terminate()
+            self._saved_thumbnail_thread.wait()
         if self._inspector_thread and self._inspector_thread.isRunning():
             self._inspector_thread.terminate()
             self._inspector_thread.wait()
@@ -8975,3 +9830,8 @@ m.add_layer(dw, vis, 'Dynamic World 2023')""",
             self._timeseries_thread.wait()
 
         event.accept()
+
+    def hideEvent(self, event):
+        """Deactivate map tools when the dock is hidden."""
+        self._shutdown_inspector(update_ui=True)
+        super().hideEvent(event)

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -34,6 +34,7 @@ class GeeDataCatalogs:
         self._catalog_dock = None
         self._settings_dock = None
         self._deps_dock = None
+        self._processing_provider = None
 
         # Dependency status (checked lazily on first button click)
         self._deps_ready = False
@@ -192,6 +193,8 @@ class GeeDataCatalogs:
         # Connect to project read signal to refresh EE layers when project opens
         QgsProject.instance().readProject.connect(self._on_project_read)
 
+        self._register_processing_provider()
+
     def unload(self):
         """Remove the plugin menu item and icon from QGIS GUI."""
         # Disconnect project signals
@@ -220,6 +223,8 @@ class GeeDataCatalogs:
             self._deps_dock.deleteLater()
             self._deps_dock = None
 
+        self._unregister_processing_provider()
+
         # Remove actions from menu
         for action in self.actions:
             self.iface.removePluginMenu("&GEE Data Catalogs", action)
@@ -231,6 +236,37 @@ class GeeDataCatalogs:
         # Remove menu
         if self.menu:
             self.menu.deleteLater()
+
+    def _register_processing_provider(self):
+        """Register QGIS Processing algorithms when Processing is available."""
+        try:
+            from qgis.core import QgsApplication
+            from .processing_provider import GeeDataCatalogsProvider
+
+            self._processing_provider = GeeDataCatalogsProvider()
+            QgsApplication.processingRegistry().addProvider(self._processing_provider)
+        except Exception:
+            self._processing_provider = None
+
+    def _unregister_processing_provider(self):
+        """Unregister QGIS Processing algorithms."""
+        if self._processing_provider is None:
+            return
+        try:
+            from qgis.core import QgsApplication
+
+            QgsApplication.processingRegistry().removeProvider(
+                self._processing_provider
+            )
+        except Exception as exc:
+            from qgis.core import QgsMessageLog, Qgis
+
+            QgsMessageLog.logMessage(
+                f"Failed to unregister Processing provider: {exc}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
+            )
+        self._processing_provider = None
 
     def _ensure_dependencies(self, callback):
         """Check dependencies and run callback if ready, otherwise show deps dock.
@@ -643,7 +679,7 @@ class GeeDataCatalogs:
         """Handle Catalog dock visibility change."""
         self._sync_panel_actions()
 
-    def open_ai_assistant(self):
+    def open_ai_assistant(self, with_context=False):
         """Open the OpenGeoAgent chat panel, or prompt for plugin installation."""
         plugin = self._get_open_geoagent_plugin()
         if plugin is None:
@@ -665,14 +701,44 @@ class GeeDataCatalogs:
             if chat_dock is not None and chat_dock.isVisible():
                 chat_dock.show()
                 chat_dock.raise_()
+                if with_context:
+                    self._prime_open_geoagent_prompt(plugin)
                 return
 
             plugin.toggle_chat_dock()
+            if with_context:
+                self._prime_open_geoagent_prompt(plugin)
         except Exception as exc:
             QMessageBox.critical(
                 self.iface.mainWindow(),
                 "OpenGeoAgent",
                 f"Failed to open the OpenGeoAgent chat panel:\n{exc}",
+            )
+
+    def _prime_open_geoagent_prompt(self, plugin):
+        """Best-effort handoff of current GEE plugin context to OpenGeoAgent."""
+        try:
+            if self._catalog_dock is None or not hasattr(
+                self._catalog_dock, "get_ai_context_snapshot"
+            ):
+                return
+            context = self._catalog_dock.get_ai_context_snapshot()
+            chat_dock = getattr(plugin, "_chat_dock", None)
+            prompt_widget = getattr(chat_dock, "prompt_input", None)
+            if prompt_widget is not None and hasattr(prompt_widget, "setPlainText"):
+                prompt_widget.setPlainText(
+                    "Use this QGIS and Earth Engine context for my next request:\n\n"
+                    f"{context}\n\nNext request: "
+                )
+                if hasattr(prompt_widget, "setFocus"):
+                    prompt_widget.setFocus()
+        except Exception as exc:
+            from qgis.core import QgsMessageLog, Qgis
+
+            QgsMessageLog.logMessage(
+                f"Could not pass context to OpenGeoAgent: {exc}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
             )
 
     def _get_open_geoagent_plugin(self):

--- a/gee_data_catalogs/gee_data_catalogs.py
+++ b/gee_data_catalogs/gee_data_catalogs.py
@@ -245,8 +245,15 @@ class GeeDataCatalogs:
 
             self._processing_provider = GeeDataCatalogsProvider()
             QgsApplication.processingRegistry().addProvider(self._processing_provider)
-        except Exception:
+        except Exception as exc:
             self._processing_provider = None
+            from qgis.core import QgsMessageLog, Qgis
+
+            QgsMessageLog.logMessage(
+                f"Failed to register Processing provider: {exc}",
+                "GEE Data Catalogs",
+                Qgis.MessageLevel.Warning,
+            )
 
     def _unregister_processing_provider(self):
         """Unregister QGIS Processing algorithms."""

--- a/gee_data_catalogs/metadata.txt
+++ b/gee_data_catalogs/metadata.txt
@@ -3,7 +3,7 @@ name=Earth Engine Data Catalogs
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Browse, search, and load Google Earth Engine data catalogs directly in QGIS.
-version=0.12.2
+version=0.13.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -25,7 +25,7 @@ about=A comprehensive plugin for exploring and loading Google Earth Engine datas
 tracker=https://github.com/opengeos/qgis-gee-data-catalogs-plugin/issues
 repository=https://github.com/opengeos/qgis-gee-data-catalogs-plugin
 
-hasProcessingProvider=no
+hasProcessingProvider=yes
 
 tags=earth engine, google, gee, remote sensing, satellite, imagery, geospatial, catalog, data
 
@@ -37,6 +37,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.13.0
+        - Add favorites, recent datasets, workflow recipes, project snapshots, export queue/history, ranked search, persistent catalog cache, AI context handoff, and QGIS Processing algorithms
     0.12.2
         - Fix macOS QGIS installer dependency installation
     0.12.1

--- a/gee_data_catalogs/processing_provider.py
+++ b/gee_data_catalogs/processing_provider.py
@@ -176,13 +176,26 @@ class GenerateSnippetAlgorithm(QgsProcessingAlgorithm):
         vis_max = self.parameterAsString(parameters, self.VIS_MAX, context).strip()
         palette = self.parameterAsString(parameters, self.PALETTE, context).strip()
 
+        def _parse_number(text, label):
+            """Parse a numeric string, preferring int but accepting float forms."""
+            try:
+                return int(text)
+            except ValueError:
+                pass
+            try:
+                return float(text)
+            except ValueError as exc:
+                raise QgsProcessingException(
+                    tr(f"Invalid {label} value: {text!r}")
+                ) from exc
+
         vis = {}
         if bands:
             vis["bands"] = [band.strip() for band in bands.split(",") if band.strip()]
         if vis_min:
-            vis["min"] = float(vis_min) if "." in vis_min else int(vis_min)
+            vis["min"] = _parse_number(vis_min, "visualization min")
         if vis_max:
-            vis["max"] = float(vis_max) if "." in vis_max else int(vis_max)
+            vis["max"] = _parse_number(vis_max, "visualization max")
         if palette:
             vis["palette"] = [
                 color.strip() for color in palette.split(",") if color.strip()
@@ -267,7 +280,16 @@ class LoadAssetAlgorithm(QgsProcessingAlgorithm):
         )
 
     def processAlgorithm(self, parameters, context, feedback):
-        import ee
+        try:
+            import ee
+        except ImportError as exc:
+            raise QgsProcessingException(
+                tr(
+                    "earthengine-api is not installed in this Python environment. "
+                    "Open the GEE Data Catalogs plugin and use the dependency "
+                    "installer, or install 'earthengine-api' manually."
+                )
+            ) from exc
 
         from .core.ee_utils import (
             add_ee_layer,

--- a/gee_data_catalogs/processing_provider.py
+++ b/gee_data_catalogs/processing_provider.py
@@ -1,0 +1,329 @@
+"""QGIS Processing provider for repeatable Earth Engine catalog workflows."""
+
+from __future__ import annotations
+
+import json
+
+from qgis.core import (
+    QgsProcessing,
+    QgsProcessingAlgorithm,
+    QgsProcessingException,
+    QgsProcessingOutputString,
+    QgsProcessingParameterBoolean,
+    QgsProcessingParameterEnum,
+    QgsProcessingParameterFileDestination,
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterString,
+    QgsProcessingProvider,
+)
+from qgis.PyQt.QtCore import QCoreApplication
+
+
+def tr(text: str) -> str:
+    return QCoreApplication.translate("GeeDataCatalogsProcessing", text)
+
+
+class SearchCatalogAlgorithm(QgsProcessingAlgorithm):
+    QUERY = "QUERY"
+    CATEGORY = "CATEGORY"
+    DATA_TYPE = "DATA_TYPE"
+    SOURCE = "SOURCE"
+    OUTPUT = "OUTPUT"
+
+    TYPES = ["Any", "Image", "ImageCollection", "FeatureCollection", "BigQueryTable"]
+    SOURCES = ["Any", "official", "community"]
+
+    def name(self):
+        return "search_catalog"
+
+    def displayName(self):
+        return tr("Search Earth Engine catalog")
+
+    def group(self):
+        return tr("Catalog")
+
+    def groupId(self):
+        return "catalog"
+
+    def shortHelpString(self):
+        return tr(
+            "Search the configured Earth Engine catalogs and write matching datasets to JSON."
+        )
+
+    def createInstance(self):
+        return SearchCatalogAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.QUERY, tr("Search query"), "", optional=True
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.CATEGORY, tr("Category"), "", optional=True
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterEnum(
+                self.DATA_TYPE, tr("Data type"), self.TYPES, defaultValue=0
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterEnum(
+                self.SOURCE, tr("Source"), self.SOURCES, defaultValue=0
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterFileDestination(
+                self.OUTPUT,
+                tr("Output JSON"),
+                tr("JSON files (*.json)"),
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        from .core.catalog_data import search_datasets
+
+        query = self.parameterAsString(parameters, self.QUERY, context)
+        category = self.parameterAsString(parameters, self.CATEGORY, context) or None
+        type_index = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
+        source_index = self.parameterAsEnum(parameters, self.SOURCE, context)
+        data_type = None if type_index == 0 else self.TYPES[type_index]
+        source = None if source_index == 0 else self.SOURCES[source_index]
+        output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
+
+        results = search_datasets(
+            query=query, category=category, data_type=data_type, source=source
+        )
+        with open(output, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2)
+        feedback.pushInfo(tr(f"Wrote {len(results)} result(s) to {output}"))
+        return {self.OUTPUT: output}
+
+
+class GenerateSnippetAlgorithm(QgsProcessingAlgorithm):
+    ASSET_ID = "ASSET_ID"
+    ASSET_TYPE = "ASSET_TYPE"
+    BANDS = "BANDS"
+    VIS_MIN = "VIS_MIN"
+    VIS_MAX = "VIS_MAX"
+    PALETTE = "PALETTE"
+    OUTPUT = "OUTPUT"
+
+    TYPES = ["Image", "ImageCollection", "FeatureCollection"]
+
+    def name(self):
+        return "generate_python_snippet"
+
+    def displayName(self):
+        return tr("Generate Earth Engine Python snippet")
+
+    def group(self):
+        return tr("Code")
+
+    def groupId(self):
+        return "code"
+
+    def createInstance(self):
+        return GenerateSnippetAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(QgsProcessingParameterString(self.ASSET_ID, tr("Asset ID")))
+        self.addParameter(
+            QgsProcessingParameterEnum(
+                self.ASSET_TYPE, tr("Asset type"), self.TYPES, defaultValue=1
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.BANDS, tr("Bands (comma-separated)"), "", optional=True
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.VIS_MIN, tr("Visualization min"), "", optional=True
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.VIS_MAX, tr("Visualization max"), "", optional=True
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.PALETTE, tr("Palette (comma-separated)"), "", optional=True
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterFileDestination(
+                self.OUTPUT,
+                tr("Output Python file"),
+                tr("Python files (*.py)"),
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        asset_id = self.parameterAsString(parameters, self.ASSET_ID, context).strip()
+        if not asset_id:
+            raise QgsProcessingException(tr("Asset ID is required."))
+        asset_type = self.TYPES[
+            self.parameterAsEnum(parameters, self.ASSET_TYPE, context)
+        ]
+        output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)
+        bands = self.parameterAsString(parameters, self.BANDS, context).strip()
+        vis_min = self.parameterAsString(parameters, self.VIS_MIN, context).strip()
+        vis_max = self.parameterAsString(parameters, self.VIS_MAX, context).strip()
+        palette = self.parameterAsString(parameters, self.PALETTE, context).strip()
+
+        vis = {}
+        if bands:
+            vis["bands"] = [band.strip() for band in bands.split(",") if band.strip()]
+        if vis_min:
+            vis["min"] = float(vis_min) if "." in vis_min else int(vis_min)
+        if vis_max:
+            vis["max"] = float(vis_max) if "." in vis_max else int(vis_max)
+        if palette:
+            vis["palette"] = [
+                color.strip() for color in palette.split(",") if color.strip()
+            ]
+
+        constructor = {
+            "Image": "ee.Image",
+            "ImageCollection": "ee.ImageCollection",
+            "FeatureCollection": "ee.FeatureCollection",
+        }[asset_type]
+        layer_expr = "asset.mosaic()" if asset_type == "ImageCollection" else "asset"
+        code = "\n".join(
+            [
+                "import ee",
+                "from gee_data_catalogs.core.ee_utils import add_ee_layer",
+                "",
+                "# ee.Initialize(project='your-project-id')",
+                f"asset = {constructor}({asset_id!r})",
+                f"vis_params = {vis!r}",
+                f"add_ee_layer({layer_expr}, vis_params, {asset_id.split('/')[-1]!r})",
+                "",
+            ]
+        )
+        with open(output, "w", encoding="utf-8") as f:
+            f.write(code)
+        feedback.pushInfo(tr(f"Wrote snippet to {output}"))
+        return {self.OUTPUT: output}
+
+
+class LoadAssetAlgorithm(QgsProcessingAlgorithm):
+    ASSET_ID = "ASSET_ID"
+    ASSET_TYPE = "ASSET_TYPE"
+    NAME = "NAME"
+    MOSAIC_COLLECTION = "MOSAIC_COLLECTION"
+    OPACITY = "OPACITY"
+    OUTPUT_NAME = "OUTPUT_NAME"
+
+    TYPES = ["Auto", "Image", "ImageCollection", "FeatureCollection"]
+
+    def name(self):
+        return "load_asset"
+
+    def displayName(self):
+        return tr("Load Earth Engine asset")
+
+    def group(self):
+        return tr("Layers")
+
+    def groupId(self):
+        return "layers"
+
+    def createInstance(self):
+        return LoadAssetAlgorithm()
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(QgsProcessingParameterString(self.ASSET_ID, tr("Asset ID")))
+        self.addParameter(
+            QgsProcessingParameterEnum(
+                self.ASSET_TYPE, tr("Asset type"), self.TYPES, defaultValue=0
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterString(self.NAME, tr("Layer name"), "", optional=True)
+        )
+        self.addParameter(
+            QgsProcessingParameterBoolean(
+                self.MOSAIC_COLLECTION, tr("Mosaic ImageCollections"), True
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterNumber(
+                self.OPACITY,
+                tr("Opacity"),
+                QgsProcessingParameterNumber.Double,
+                defaultValue=1.0,
+                minValue=0.0,
+                maxValue=1.0,
+            )
+        )
+        self.addOutput(
+            QgsProcessingOutputString(self.OUTPUT_NAME, tr("Loaded layer name"))
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        import ee
+
+        from .core.ee_utils import (
+            add_ee_layer,
+            detect_asset_type,
+            initialize_ee,
+            is_ee_initialized,
+        )
+
+        asset_id = self.parameterAsString(parameters, self.ASSET_ID, context).strip()
+        if not asset_id:
+            raise QgsProcessingException(tr("Asset ID is required."))
+        type_index = self.parameterAsEnum(parameters, self.ASSET_TYPE, context)
+        asset_type = None if type_index == 0 else self.TYPES[type_index]
+        if not is_ee_initialized() and not initialize_ee():
+            raise QgsProcessingException(tr("Earth Engine is not initialized."))
+        if asset_type is None:
+            asset_type = detect_asset_type(asset_id)
+        name = (
+            self.parameterAsString(parameters, self.NAME, context).strip()
+            or asset_id.split("/")[-1]
+        )
+        opacity = self.parameterAsDouble(parameters, self.OPACITY, context)
+        mosaic = self.parameterAsBoolean(parameters, self.MOSAIC_COLLECTION, context)
+
+        if asset_type == "Image":
+            ee_object = ee.Image(asset_id)
+        elif asset_type == "ImageCollection":
+            collection = ee.ImageCollection(asset_id)
+            ee_object = collection.mosaic() if mosaic else collection
+        elif asset_type == "FeatureCollection":
+            ee_object = ee.FeatureCollection(asset_id)
+        else:
+            raise QgsProcessingException(tr(f"Unsupported asset type: {asset_type}"))
+
+        add_ee_layer(ee_object, {}, name, opacity=opacity)
+        feedback.pushInfo(tr(f"Loaded {name}"))
+        return {self.OUTPUT_NAME: name}
+
+
+class GeeDataCatalogsProvider(QgsProcessingProvider):
+    def loadAlgorithms(self):
+        self.addAlgorithm(SearchCatalogAlgorithm())
+        self.addAlgorithm(GenerateSnippetAlgorithm())
+        self.addAlgorithm(LoadAssetAlgorithm())
+
+    def id(self):
+        return "gee_data_catalogs"
+
+    def name(self):
+        return tr("GEE Data Catalogs")
+
+    def longName(self):
+        return self.name()
+
+    def icon(self):
+        from qgis.PyQt.QtGui import QIcon
+        import os
+
+        return QIcon(os.path.join(os.path.dirname(__file__), "icons", "icon.svg"))

--- a/tests/test_catalog_enhancements.py
+++ b/tests/test_catalog_enhancements.py
@@ -1,0 +1,105 @@
+import json
+
+from gee_data_catalogs.core import catalog_data, user_state
+from gee_data_catalogs.dialogs.catalog_dock import CatalogDockWidget
+
+
+def test_search_datasets_ranks_exact_and_weighted_matches(monkeypatch):
+    datasets = [
+        {
+            "id": "COMMUNITY/S2_MISC",
+            "name": "Miscellaneous optical imagery",
+            "description": "Mentions sentinel in passing",
+            "type": "ImageCollection",
+            "source": "community",
+            "keywords": [],
+        },
+        {
+            "id": "COPERNICUS/S2_SR_HARMONIZED",
+            "name": "Sentinel-2 MSI: MultiSpectral Instrument, Level-2A",
+            "description": "Surface reflectance",
+            "type": "ImageCollection",
+            "source": "official",
+            "keywords": ["sentinel", "surface reflectance"],
+        },
+    ]
+    monkeypatch.setattr(
+        catalog_data, "get_all_datasets", lambda include_community=True: datasets
+    )
+
+    results = catalog_data.search_datasets(query="sentinel surface reflectance")
+
+    assert results[0]["id"] == "COPERNICUS/S2_SR_HARMONIZED"
+    assert results[0]["_search_score"] > results[1]["_search_score"]
+
+
+class _FakeSettings:
+    def __init__(self):
+        self.values = {}
+
+    def value(self, key, default="", type=str):
+        value = self.values.get(key, default)
+        if type is bool:
+            return bool(value)
+        if type is int:
+            return int(value)
+        return value
+
+    def setValue(self, key, value):
+        self.values[key] = value
+
+
+def test_favorites_and_recents_are_persisted_as_compact_records(monkeypatch):
+    settings = _FakeSettings()
+    monkeypatch.setattr(user_state, "_settings", lambda: settings)
+
+    dataset = {
+        "id": "USGS/SRTMGL1_003",
+        "name": "SRTM",
+        "type": "Image",
+        "source": "official",
+        "description": "Elevation",
+        "thumbnail": "https://example.com/thumb.png",
+        "unused": "not persisted",
+    }
+
+    user_state.add_favorite(dataset)
+    user_state.record_recent_dataset(dataset, "load")
+
+    assert user_state.is_favorite("USGS/SRTMGL1_003")
+    assert user_state.get_favorites()[0]["name"] == "SRTM"
+    assert user_state.get_favorites()[0]["thumbnail"] == "https://example.com/thumb.png"
+    assert "unused" not in user_state.get_favorites()[0]
+    assert user_state.get_recents()[0]["last_action"] == "load"
+
+    raw = settings.values["GeeDataCatalogs/favorites"]
+    assert json.loads(raw)[0]["id"] == "USGS/SRTMGL1_003"
+
+    user_state.remove_favorite("USGS/SRTMGL1_003")
+
+    assert not user_state.is_favorite("USGS/SRTMGL1_003")
+    assert user_state.get_favorites() == []
+
+
+def test_saved_dataset_info_html_includes_thumbnail_placeholder():
+    html = CatalogDockWidget._dataset_info_html(
+        None,
+        {
+            "id": "USGS/SRTMGL1_003",
+            "name": "SRTM",
+            "type": "Image",
+            "source": "official",
+            "thumbnail": "https://example.com/thumb.png",
+        },
+    )
+
+    assert "saved-thumbnail-placeholder" in html
+
+
+def test_default_recipes_include_hls_workflows():
+    recipes = {recipe["id"]: recipe for recipe in user_state.DEFAULT_RECIPES}
+
+    assert recipes["hls_s30_rgb"]["asset_id"] == "NASA/HLS/HLSS30/v002"
+    assert recipes["hls_l30_rgb"]["asset_id"] == "NASA/HLS/HLSL30/v002"
+    assert recipes["hls_s30_reflectance_timeseries"]["target"] == "timeseries"
+    assert recipes["hls_l30_reflectance_timeseries"]["bands"] == "B2,B3,B4,B5,B6,B7"

--- a/tests/test_ee_layer_add.py
+++ b/tests/test_ee_layer_add.py
@@ -117,3 +117,164 @@ def test_add_ee_layer_falls_back_when_qgis_geemap_returns_invalid(monkeypatch):
     assert added_layers == [(layer, False)]
     assert inserted_layers == [(0, layer)]
     assert removed_layers == []
+
+
+def test_add_ee_layer_expands_named_palette_before_get_map_id(monkeypatch):
+    captured_vis = []
+
+    class _FakeLayer:
+        def __init__(self, uri="", name="", provider=""):
+            self.uri = uri
+            self._name = name
+            self.custom_properties = {}
+
+        def isValid(self):
+            return True
+
+        def id(self):
+            return self._name
+
+        def name(self):
+            return self._name
+
+        def renderer(self):
+            return None
+
+        def setCustomProperty(self, key, value):
+            self.custom_properties[key] = value
+
+    class _LayerTreeRoot:
+        def insertLayer(self, index, layer):
+            pass
+
+        def findLayer(self, layer_id):
+            return None
+
+    class _Project:
+        def mapLayersByName(self, name):
+            return []
+
+        def removeMapLayer(self, layer_id):
+            pass
+
+        def addMapLayer(self, layer, add_to_legend):
+            pass
+
+        def layerTreeRoot(self):
+            return _LayerTreeRoot()
+
+    class _QgsProject:
+        @staticmethod
+        def instance():
+            return _Project()
+
+    class _FakeImage:
+        def getMapId(self, vis_params):
+            captured_vis.append(vis_params)
+            return {
+                "tile_fetcher": types.SimpleNamespace(
+                    url_format="https://example.com/{z}/{x}/{y}"
+                )
+            }
+
+        def get(self, key):
+            raise RuntimeError("no asset id")
+
+    ee_module = types.SimpleNamespace(
+        Image=_FakeImage,
+        ImageCollection=type("ImageCollection", (), {}),
+        FeatureCollection=type("FeatureCollection", (), {}),
+        serializer=types.SimpleNamespace(toJSON=lambda obj: "{}"),
+    )
+
+    monkeypatch.setattr(ee_utils, "ee", ee_module)
+    monkeypatch.setattr(ee_utils, "QgsRasterLayer", _FakeLayer)
+    monkeypatch.setattr(ee_utils, "QgsProject", _QgsProject)
+    monkeypatch.setattr(
+        ee_utils,
+        "_colormap_colors",
+        lambda name, n_colors=256: ["#000000", "#ffffff"] if name == "terrain" else [],
+    )
+    monkeypatch.setitem(sys.modules, "qgis_geemap", types.ModuleType("qgis_geemap"))
+
+    ee_utils.add_ee_layer(_FakeImage(), {"palette": "terrain"}, "DEM")
+
+    assert captured_vis == [{"palette": ["#000000", "#ffffff"]}]
+
+
+def test_add_ee_layer_renames_valid_qgis_geemap_layer(monkeypatch):
+    class _FakeLayer:
+        def __init__(self, uri="", name="Layer", provider=""):
+            self.uri = uri
+            self._name = name
+            self.custom_properties = {}
+
+        def isValid(self):
+            return True
+
+        def id(self):
+            return self._name
+
+        def name(self):
+            return self._name
+
+        def setName(self, name):
+            self._name = name
+
+        def renderer(self):
+            return None
+
+        def setCustomProperty(self, key, value):
+            self.custom_properties[key] = value
+
+    class _Project:
+        def mapLayersByName(self, name):
+            return []
+
+        def removeMapLayer(self, layer_id):
+            pass
+
+    class _QgsProject:
+        @staticmethod
+        def instance():
+            return _Project()
+
+    class _FakeImage:
+        def get(self, key):
+            raise RuntimeError("no asset id")
+
+    returned_layer = _FakeLayer(name="Layer")
+
+    class _FakeMap:
+        def add_layer(self, ee_object, vis_params, name, shown, opacity):
+            return returned_layer
+
+    ee_module = types.SimpleNamespace(
+        Image=_FakeImage,
+        ImageCollection=type("ImageCollection", (), {}),
+        FeatureCollection=type("FeatureCollection", (), {}),
+        serializer=types.SimpleNamespace(toJSON=lambda obj: "{}"),
+    )
+    qgis_geemap_module = types.ModuleType("qgis_geemap.core.qgis_map")
+    qgis_geemap_module.Map = _FakeMap
+
+    monkeypatch.setattr(ee_utils, "ee", ee_module)
+    monkeypatch.setattr(ee_utils, "QgsRasterLayer", _FakeLayer)
+    monkeypatch.setattr(ee_utils, "QgsProject", _QgsProject)
+    monkeypatch.setitem(sys.modules, "qgis_geemap", types.ModuleType("qgis_geemap"))
+    monkeypatch.setitem(
+        sys.modules, "qgis_geemap.core", types.ModuleType("qgis_geemap.core")
+    )
+    monkeypatch.setitem(sys.modules, "qgis_geemap.core.qgis_map", qgis_geemap_module)
+
+    layer = ee_utils.add_ee_layer(_FakeImage(), {}, "Elevation")
+
+    assert layer is returned_layer
+    assert layer.name() == "Elevation"
+    assert "Elevation" in ee_utils.get_ee_layers()
+
+
+def test_normalize_vis_params_splits_comma_palette():
+    assert ee_utils.normalize_vis_params({"palette": "red, yellow, #0000ff"}) == {
+        "palette": ["red", "yellow", "#0000ff"]
+    }


### PR DESCRIPTION
## Summary
- Add favorites, recent datasets, reusable workflow recipes, project snapshot copy/share, and queued exports with run history to the catalog dock.
- Improve catalog UX with relevance-ranked search, persistent disk-backed catalog cache (faster startup, offline fallback), and AI Assistant context handoff.
- Register a QGIS Processing provider so catalog search, snippet generation, and EE asset loading are usable from the Processing toolbox and Model Builder.
- Bumps plugin version to 0.13.0 and updates the changelog.

## Test plan
- [ ] Open the catalog dock in QGIS 3.28+ and verify favorites, recents, and recipes persist across restarts.
- [ ] Run a ranked search and confirm relevance ordering plus offline catalog fallback when network is unavailable.
- [ ] Queue multiple exports and verify status/history entries.
- [ ] Run the new Processing algorithms (catalog search, snippet generation, EE asset load) from the Processing toolbox and Model Builder.
- [ ] `pre-commit run --all-files` passes (black, codespell, bandit).