### PR TITLE
fix: install export dependencies (xee, rioxarray, geopandas) in managed venv

### DIFF
--- a/gee_data_catalogs/core/venv_manager.py
+++ b/gee_data_catalogs/core/venv_manager.py
@@ -26,6 +26,13 @@ REQUIRED_PACKAGES = [
     ("earthengine-api", ">=1.4.0"),
     ("geemap", ""),
     ("GeoAgent", "[providers]>=1.1.1"),
+    # Export dependencies: xee + rioxarray power Cloud Optimized GeoTIFF
+    # (COG) image exports, while geopandas backs the vector/feature exports.
+    # xarray and pandas are pulled in transitively (xee -> xarray,
+    # geopandas -> pandas), so they do not need to be listed explicitly.
+    ("xee", ""),
+    ("rioxarray", ""),
+    ("geopandas", ""),
 ]
 
 # Module-level guard so the "added venv site-packages to sys.path" message

--- a/gee_data_catalogs/dialogs/catalog_dock.py
+++ b/gee_data_catalogs/dialogs/catalog_dock.py
@@ -784,7 +784,9 @@ class ExportWorkerThread(QThread):
         except ImportError as e:
             raise ImportError(
                 f"Required packages not available: {e}\n"
-                "Please install xarray and xee: pip install xarray xee"
+                "Open the plugin's Dependencies panel and click Install/Update "
+                "to add xee and xarray, or install them manually with: "
+                "pip install xarray xee"
             )
 
         self.progress.emit("Opening dataset with xee...")
@@ -820,7 +822,8 @@ class ExportWorkerThread(QThread):
         except ImportError:
             raise ImportError(
                 "rioxarray is required for COG export.\n"
-                "Please install it: pip install rioxarray"
+                "Open the plugin's Dependencies panel and click Install/Update "
+                "to add it, or install it manually with: pip install rioxarray"
             )
 
         # Handle xee dimension naming for rioxarray
@@ -931,7 +934,8 @@ class ExportWorkerThread(QThread):
         except ImportError:
             raise ImportError(
                 "geopandas is required for vector export.\n"
-                "Please install it: pip install geopandas"
+                "Open the plugin's Dependencies panel and click Install/Update "
+                "to add it, or install it manually with: pip install geopandas"
             )
 
         try:
@@ -1059,7 +1063,9 @@ class TimeSeriesExportWorkerThread(QThread):
         except ImportError as e:
             raise ImportError(
                 f"Required packages not available: {e}\n"
-                "Please install xarray and xee: pip install xarray xee"
+                "Open the plugin's Dependencies panel and click Install/Update "
+                "to add xee and xarray, or install them manually with: "
+                "pip install xarray xee"
             )
 
         # Convert region to ee.Geometry if needed
@@ -1094,7 +1100,8 @@ class TimeSeriesExportWorkerThread(QThread):
         except ImportError:
             raise ImportError(
                 "rioxarray is required for COG export.\n"
-                "Please install it: pip install rioxarray"
+                "Open the plugin's Dependencies panel and click Install/Update "
+                "to add it, or install it manually with: pip install rioxarray"
             )
 
         # Handle xee dimension naming for rioxarray
@@ -1822,7 +1829,9 @@ class VectorTimeSeriesExtractionWorker(QThread):
             except ImportError as exc:
                 raise ImportError(
                     "geopandas and pandas are required for vector time series extraction.\n"
-                    "Please install them: pip install geopandas pandas"
+                    "Open the plugin's Dependencies panel and click Install/Update "
+                    "to add them, or install them manually with: "
+                    "pip install geopandas pandas"
                 ) from exc
 
             if not self.vector_features:
@@ -6450,7 +6459,9 @@ class CatalogDockWidget(QDockWidget):
         except ImportError as e:
             raise ImportError(
                 f"Required packages not available: {e}\n"
-                "Please install xarray and xee: pip install xarray xee"
+                "Open the plugin's Dependencies panel and click Install/Update "
+                "to add xee and xarray, or install them manually with: "
+                "pip install xarray xee"
             )
 
         self.export_status_label.setText("Opening dataset with xee...")
@@ -6485,7 +6496,8 @@ class CatalogDockWidget(QDockWidget):
         except ImportError:
             raise ImportError(
                 "rioxarray is required for COG export.\n"
-                "Please install it: pip install rioxarray"
+                "Open the plugin's Dependencies panel and click Install/Update "
+                "to add it, or install it manually with: pip install rioxarray"
             )
 
         # Handle xee dimension naming for rioxarray
@@ -6632,7 +6644,8 @@ class CatalogDockWidget(QDockWidget):
         except ImportError:
             raise ImportError(
                 "geopandas is required for vector export.\n"
-                "Please install it: pip install geopandas"
+                "Open the plugin's Dependencies panel and click Install/Update "
+                "to add it, or install it manually with: pip install geopandas"
             )
 
         try:

--- a/gee_data_catalogs/dialogs/dependency_dialog.py
+++ b/gee_data_catalogs/dialogs/dependency_dialog.py
@@ -72,7 +72,7 @@ class DependencyDockWidget(QDockWidget):
             "<b>geopandas</b>.<br><br>"
             "Click 'Install Dependencies' to install them in an<br>"
             "isolated virtual environment at:<br>"
-            "<code>~/.qgis_gee_data_catalogs/</code><br><br>"
+            "<code>~/.qgis_gee_data_catalogs/venv</code><br><br>"
             "Your QGIS Python environment will not be modified."
         )
         info.setWordWrap(True)

--- a/gee_data_catalogs/dialogs/dependency_dialog.py
+++ b/gee_data_catalogs/dialogs/dependency_dialog.py
@@ -67,7 +67,9 @@ class DependencyDockWidget(QDockWidget):
         info = QLabel(
             "This plugin requires the <b>earthengine-api</b> and "
             "<b>geemap</b> Python packages. The AI assistant also requires "
-            "<b>GeoAgent</b> and model provider clients.<br><br>"
+            "<b>GeoAgent</b> and model provider clients. Exporting images "
+            "and features uses <b>xee</b>, <b>rioxarray</b>, and "
+            "<b>geopandas</b>.<br><br>"
             "Click 'Install Dependencies' to install them in an<br>"
             "isolated virtual environment at:<br>"
             "<code>~/.qgis_gee_data_catalogs/</code><br><br>"

--- a/tests/test_ai_provider_config.py
+++ b/tests/test_ai_provider_config.py
@@ -103,6 +103,15 @@ def test_geoagent_dependency_requires_generated_snippet_tool_version():
     assert ("GeoAgent", "[providers]>=1.1.1") in venv_manager.REQUIRED_PACKAGES
 
 
+def test_export_dependencies_in_required_packages():
+    """Export needs xee/rioxarray (COG images) and geopandas (vector features)."""
+    package_names = [name for name, _ in venv_manager.REQUIRED_PACKAGES]
+
+    assert "xee" in package_names, "xee required for Cloud Optimized GeoTIFF exports"
+    assert "rioxarray" in package_names, "rioxarray required for COG exports"
+    assert "geopandas" in package_names, "geopandas required for vector exports"
+
+
 def test_credential_value_prefers_saved_setting_over_environment(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "env-key")
     harness = _CredentialHarness({"GeeDataCatalogs/openai_api_key": "saved-key"})


### PR DESCRIPTION
## Summary

Fixes #74, where image export fails with `ModuleNotFoundError: No module named 'xee'` even though the user installed xee in a separate environment (pixi).

## Root cause

The plugin installs its Python dependencies into an isolated managed virtual environment (`~/.qgis_gee_data_catalogs/venv`) and prepends that venv's `site-packages` to `sys.path` at load time. However, `REQUIRED_PACKAGES` only listed `earthengine-api`, `geemap`, and `GeoAgent`.

The export code paths import additional packages that were never installed into the managed venv:

- Image / COG export: `xee`, `xarray`, `rioxarray`
- Feature / vector export: `geopandas`, `pandas`

So `import xee` failed at export time regardless of what the user installed elsewhere, because QGIS resolves imports against the managed venv's `site-packages`, not the user's pixi/conda environment (the reporter was also launching a standalone QGIS-LTR install, not their pixi QGIS).

## Changes

- Add `xee`, `rioxarray`, and `geopandas` to `REQUIRED_PACKAGES` so the managed venv provides everything the export features need (`xarray` and `pandas` are pulled in transitively).
- Update the export `ImportError` messages to direct users to the plugin's Dependencies panel (Install/Update) rather than a bare `pip install`, which does not help in the managed-venv model.
- Mention the export packages in the Dependencies panel info text. The package status list is generated from `REQUIRED_PACKAGES`, so the new packages appear there automatically.

Existing installs will report the new packages as missing via `get_venv_status()`, which surfaces the Dependencies panel and prompts a one-click update.

## Testing

- `pytest tests/test_ai_provider_config.py` (14 passed)
- `pre-commit run --all-files` (black, codespell, bandit all pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Cloud Optimized GeoTIFF (COG) image exports and vector/feature exports via new export dependencies.

* **Improvements**
  * Improved install/error messages to direct users to the Dependencies panel (with fallback pip commands) and clarified the virtual environment path in the UI.
  * Updated in-app documentation to list export-related packages.

* **Tests**
  * Added a test to verify required export dependencies are listed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->