### PR TITLE
chore(release): bump version to 0.14.1

### DIFF
--- a/gee_data_catalogs/metadata.txt
+++ b/gee_data_catalogs/metadata.txt
@@ -3,7 +3,7 @@ name=Earth Engine Data Catalogs
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Browse, search, and load Google Earth Engine data catalogs directly in QGIS.
-version=0.14.0
+version=0.14.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -37,6 +37,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.14.1
+        - Fix image and feature export failing with "No module named 'xee'" by installing xee, rioxarray, and geopandas into the managed environment (#74)
     0.14.0
         - Add extraction of Earth Engine image time series to vector features (points/polygons) with band selection, temporal aggregation, and filtering
     0.13.0


### PR DESCRIPTION
Patch release bumping the plugin version to **0.14.1**.

## Changes
- `metadata.txt`: `version=0.14.1` and a new changelog entry.

## Changelog (0.14.1)
- Fix image and feature export failing with `No module named 'xee'` by installing `xee`, `rioxarray`, and `geopandas` into the managed environment (#74, via #75).

Once merged, a GitHub release tagged `v0.14.1` will be cut, which triggers the Publish workflow to package the plugin and upload it to plugins.qgis.org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved image and feature export failures that were preventing successful data export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->